### PR TITLE
Add associated-domains for web credentials on the bikeindex.org domain

### DIFF
--- a/BikeIndex/BikeIndex.entitlements
+++ b/BikeIndex/BikeIndex.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:bikeindex.org</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>


### PR DESCRIPTION
# Description

- Add webcredentials:bikeindex.org to associated-domains for credential authorization with bikeindex.org
- This allows easier and faster authentication for users who have a password manager storing credentials for the matched domain

### Resources

- Documentation for webcredentials: https://developer.apple.com/documentation/xcode/supporting-associated-domains

## Requirements

- Requires bikeindex.org/.well-known/apple-app-site-association to contain the appropriate concatenated app ID prefix and bundle ID in PR https://github.com/bikeindex/bike_index/pull/2586