### PR TITLE
Fix Xcode 16 warnings

### DIFF
--- a/BikeIndex.xcodeproj/project.pbxproj
+++ b/BikeIndex.xcodeproj/project.pbxproj
@@ -559,7 +559,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1520;
+				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					04F4B8F62B098ADB009442B5 = {
 						CreatedOnToolsVersion = 15.0.1;
@@ -843,7 +843,6 @@
 		04EA11252B25135D0024CDDD /* Debug BikeIndex.org */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -865,7 +864,6 @@
 		04EA11262B25135D0024CDDD /* Debug BikeIndex.org */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
@@ -1088,7 +1086,6 @@
 		04F4B9222B098ADE009442B5 /* Debug (development) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1110,7 +1107,6 @@
 		04F4B9232B098ADE009442B5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1132,7 +1128,6 @@
 		04F4B9252B098ADE009442B5 /* Debug (development) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
@@ -1153,7 +1148,6 @@
 		04F4B9262B098ADE009442B5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;

--- a/BikeIndex.xcodeproj/xcshareddata/xcschemes/Debug (bikeindex.org).xcscheme
+++ b/BikeIndex.xcodeproj/xcshareddata/xcschemes/Debug (bikeindex.org).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1520"
+   LastUpgradeVersion = "1600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BikeIndex.xcodeproj/xcshareddata/xcschemes/Debug (development).xcscheme
+++ b/BikeIndex.xcodeproj/xcshareddata/xcschemes/Debug (development).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1520"
+   LastUpgradeVersion = "1600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/BikeIndex/Model/User.swift
+++ b/BikeIndex/Model/User.swift
@@ -31,7 +31,7 @@ import OSLog
     }
 }
 
-@Model final class User { // CustomDebugStringConvertible {
+@Model final class User {
     @Attribute(.unique) fileprivate(set) var email: String
     fileprivate(set) var username: String
     fileprivate(set) var name: String

--- a/BikeIndex/Model/User.swift
+++ b/BikeIndex/Model/User.swift
@@ -10,7 +10,7 @@ import SwiftData
 import OSLog
 
 @Model final class AuthenticatedUser: BikeIndexIdentifiable, CustomDebugStringConvertible {
-    // TODO: Check if this can be Int
+    // TODO: Check if `identifier` can be Int
     @Attribute(.unique) private(set) var identifier: String
     @Relationship(deleteRule: .cascade) var user: User?
 
@@ -55,11 +55,11 @@ import OSLog
 }
 
 @Model final class Organization {
-    @Attribute(.unique) let identifier: Int
-    let name: String
-    let slug: String
-    let accessToken: Token
-    let userIsOrganizationAdmin: Bool
+    @Attribute(.unique) var identifier: Int
+    var name: String
+    var slug: String
+    var accessToken: Token
+    var userIsOrganizationAdmin: Bool
 
     //    @Relationship(deleteRule: .cascade, inverse: \AuthenticatedUser.memberships)
     //    var authorizedUsers: [AuthenticatedUser]? = []

--- a/BikeIndex/View/MainContent/ContentView.swift
+++ b/BikeIndex/View/MainContent/ContentView.swift
@@ -133,7 +133,7 @@ final class ContentModel {
 
 // MARK: - Previews
 
-#Preview {
+#Preview("Empty data") {
     // MARK: Empty Data Preview
     do {
         let client = try Client()
@@ -145,13 +145,12 @@ final class ContentModel {
         return ContentView()
             .environment(client)
             .modelContainer(container)
-            .previewDisplayName("Empty data")
     } catch let error {
         return Text("Failed to load preview \(error.localizedDescription)")
     }
 }
 
-#Preview {
+#Preview("1 Bike Preview") {
     // MARK: 1 Bike Preview
     do {
         let client = try Client()
@@ -169,7 +168,6 @@ final class ContentModel {
         return ContentView()
             .environment(client)
             .modelContainer(container)
-            .previewDisplayName("1 Bike Preview")
     } catch let error {
         return Text("Failed to load preview \(error.localizedDescription)")
     }

--- a/BikeIndex/View/Registering/ManufacturerEntryView.swift
+++ b/BikeIndex/View/Registering/ManufacturerEntryView.swift
@@ -118,7 +118,6 @@ struct ManufacturerEntryView: View {
         searchText = $0
     })
 
-    let searching = true
     let state = FocusState<ManufacturerEntryView.EditState?>()
 
     do {

--- a/BikeIndex/View/Registering/RegisterBikeView.swift
+++ b/BikeIndex/View/Registering/RegisterBikeView.swift
@@ -329,7 +329,7 @@ struct RegisterBikeView: View {
 }
 
 // MARK: - Normal Mode Preview
-#Preview {
+#Preview("Normal Mode Preview") {
     do {
         let bike = Bike()
         let client = try Client()
@@ -348,7 +348,6 @@ struct RegisterBikeView: View {
             RegisterBikeView(mode: .myOwnBike, bike: bike)
                 .environment(client)
                 .modelContainer(container)
-                .previewDisplayName("Normal Mode Preview")
         }
     } catch let error {
         return Text("Failed to load preview \(error.localizedDescription)")
@@ -356,7 +355,7 @@ struct RegisterBikeView: View {
 }
 
 // MARK: - Stolen Mode Preview
-#Preview {
+#Preview("Stolen Mode Preview") {
     do {
         let bike = Bike()
         let client = try Client()
@@ -375,7 +374,6 @@ struct RegisterBikeView: View {
             RegisterBikeView(mode: .myStolenBike, bike: bike)
                 .environment(client)
                 .modelContainer(container)
-                .previewDisplayName("Stolen Mode Preview")
         }
     } catch let error {
         return Text("Failed to load preview \(error.localizedDescription)")

--- a/BikeIndex/View/Settings/AcknowledgementsListView.swift
+++ b/BikeIndex/View/Settings/AcknowledgementsListView.swift
@@ -69,9 +69,15 @@ struct AcknowledgementsListView: View {
     }
 }
 
+#Preview("AcknowledgementListItemView") {
+    AcknowledgementListItemView(package: AcknowledgementPackage.all.first(where: {$0.title == "Bike Index"}).unsafelyUnwrapped)
+        .environment(try! Client())
+}
+
 #Preview {
     NavigationStack {
         AcknowledgementsListView()
+            .environment(try! Client())
             .navigationTitle("Acknowledgements")
     }
 }

--- a/BikeIndex/View/TextLink.swift
+++ b/BikeIndex/View/TextLink.swift
@@ -59,7 +59,7 @@ enum BikeIndexLink: Identifiable {
         let markdownSource: String
         switch self {
         case .oauthApplications:
-            markdownSource = "[Edit your OAuth Applications at bikeindex.org](\(link(base: base))"
+            markdownSource = "[Edit your OAuth Applications at bikeindex.org](\(link(base: base)))"
         case .serials:
             markdownSource = "Every bike has a unique serial number, it's how they are identified. To learn more or see some examples, [go to our serial page](\(link(base: base)))."
         case .stolenBikeFAQ:

--- a/BikeIndex/View/Web/NavigatorChild.swift
+++ b/BikeIndex/View/Web/NavigatorChild.swift
@@ -5,7 +5,7 @@
 //  Created by Jack on 1/14/24.
 //
 
-import WebKit
+@preconcurrency import WebKit // TODO: Upgrade WebKit for Swift 6 concurrency
 import OSLog
 
 open class NavigatorChild: NSObject, WKNavigationDelegate {


### PR DESCRIPTION
# Description

- Fix warnings from project built with Xcode Version 16.0 (16A242d).
- Clean up some minor comments
- Note: these changes **do not** correct Swift 6 Strict Concurrency Checking warnings. That will be addressed separately. 