### PR TITLE
fix: manufacturer uniqueness

### DIFF
--- a/BikeIndex.xcodeproj/project.pbxproj
+++ b/BikeIndex.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		046B0A372B251E58006519A7 /* AppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A352B251E58006519A7 /* AppIconPicker.swift */; };
 		046B0A382B251E58006519A7 /* TextLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A362B251E58006519A7 /* TextLink.swift */; };
 		046B0A3A2B251E67006519A7 /* AlternateIconsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A392B251E67006519A7 /* AlternateIconsModel.swift */; };
+		04706F2D2CE99FF500C55831 /* ManufacturerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04706F2C2CE99FF500C55831 /* ManufacturerTests.swift */; };
 		0482AF1E2BCB59FE0077B0BF /* CameraCaptureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0482AF1D2BCB59FE0077B0BF /* CameraCaptureButton.swift */; };
 		0485E9C72B9E2FA70071C48B /* Logger+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A3C2B251E91006519A7 /* Logger+Tests.swift */; };
 		0490A5EF2B26972600C4EC1E /* BikeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0490A5EE2B26972600C4EC1E /* BikeResponse.swift */; };
@@ -128,6 +129,7 @@
 		046B0A3D2B251E91006519A7 /* UserRelationshipTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRelationshipTests.swift; sourceTree = "<group>"; };
 		046B0A3E2B251E92006519A7 /* BikeIndexOrgApiV3Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BikeIndexOrgApiV3Tests.swift; sourceTree = "<group>"; };
 		046B0A3F2B251E92006519A7 /* MockData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
+		04706F2C2CE99FF500C55831 /* ManufacturerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManufacturerTests.swift; sourceTree = "<group>"; };
 		0482AF1D2BCB59FE0077B0BF /* CameraCaptureButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCaptureButton.swift; sourceTree = "<group>"; };
 		0490A5EE2B26972600C4EC1E /* BikeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeResponse.swift; sourceTree = "<group>"; };
 		0490A5F02B269F7800C4EC1E /* AddBikeOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBikeOutput.swift; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 			children = (
 				046B0A3E2B251E92006519A7 /* BikeIndexOrgApiV3Tests.swift */,
 				046B0A3D2B251E91006519A7 /* UserRelationshipTests.swift */,
+				04706F2C2CE99FF500C55831 /* ManufacturerTests.swift */,
 				046B0A3B2B251E91006519A7 /* UserTests.swift */,
 				04F4B92E2B098B4F009442B5 /* BikeModelTests.swift */,
 				043033302B3E6FA100FD126F /* BikeRegistrationTests.swift */,
@@ -708,6 +711,7 @@
 				0401235E2B817BD50045FECE /* BikeIndexOrgApiV3Tests.swift in Sources */,
 				0401235F2B817BD50045FECE /* BikeRegistrationTests.swift in Sources */,
 				04C736EE2B8180FD00D2BDA3 /* ClientRefreshTests.swift in Sources */,
+				04706F2D2CE99FF500C55831 /* ManufacturerTests.swift in Sources */,
 				040123622B817BD50045FECE /* UserRelationshipTests.swift in Sources */,
 				040123612B817BD50045FECE /* Logger+Tests.swift in Sources */,
 				040123652B817BD50045FECE /* OAuthTests.swift in Sources */,

--- a/BikeIndex/View/Registering/ManufacturerEntryView.swift
+++ b/BikeIndex/View/Registering/ManufacturerEntryView.swift
@@ -58,9 +58,13 @@ struct ManufacturerEntryView: View {
                         return
                     }
 
-                    for manufacturer in autocompleteResponse.matches {
-                        modelContext.insert(manufacturer.modelInstance())
+                    do {
+                        for manufacturer in autocompleteResponse.matches {
+                            modelContext.insert(manufacturer.modelInstance())
+                        }
+                        try? modelContext.save()
                     }
+
 
                     Logger.views.debug("ManufacturerEntryView received response \(String(describing: autocompleteResponse), privacy: .public)")
 

--- a/BikeIndexTests/ManufacturerTests.swift
+++ b/BikeIndexTests/ManufacturerTests.swift
@@ -1,0 +1,64 @@
+//
+//  ManufacturerTests.swift
+//  BikeIndexTests
+//
+//  Created by Jack on 11/16/24.
+//
+
+import XCTest
+import SwiftData
+import Testing
+import OSLog
+@testable import BikeIndex
+
+struct ManufacturerTests {
+
+    /// Ensure that a duplicate with the same ``AutocompleteManufacturer/identifier`` is 'upserted' instead of added.
+    @Test func test_manufacturer_deduplication() async throws {
+        func createSampleManufacturer(text: String = "Jamis") -> AutocompleteManufacturer {
+            AutocompleteManufacturer(
+                text: text,
+                category: "frame_mnfg",
+                slug: "jamis",
+                priority: 100,
+                searchId: "m_201",
+                identifier: 201
+            )
+        }
+
+        let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
+        let container = try ModelContainer(
+            for: AutocompleteManufacturer.self,
+            configurations: config
+        )
+        let descriptor = FetchDescriptor<AutocompleteManufacturer>()
+
+        // https://developer.apple.com/documentation/swiftdata/maintaining-a-local-copy-of-server-data
+        #expect(await container.mainContext.autosaveEnabled, "Autosave must be enabled for deduplication")
+        let manufacturer_preCreate = try await container.mainContext.fetch(descriptor)
+        #expect(manufacturer_preCreate.count == 0)
+
+        let jamisManufacturer = createSampleManufacturer()
+        do {
+            await container.mainContext.insert(jamisManufacturer)
+            try await container.mainContext.save()
+        }
+
+        let manufacturer_postInsert = try await container.mainContext.fetch(descriptor)
+        #expect(manufacturer_postInsert.count == 1)
+        #expect(manufacturer_postInsert.first?.text == "Jamis")
+
+        // MARK: Perform actual test
+        var duplicateEntry = createSampleManufacturer(text: "Jamis 2")
+        do {
+            await container.mainContext.insert(duplicateEntry)
+            try await container.mainContext.save()
+        }
+        let fetch_postDuplicateInsert = try await container.mainContext.fetch(descriptor)
+        #expect(fetch_postDuplicateInsert.count == 1,
+                "Duplicate found, \(fetch_postDuplicateInsert.map(\.id)), \(fetch_postDuplicateInsert.map(\.identifier))")
+        #expect(manufacturer_postInsert.first?.text == "Jamis 2",
+                "Only one entry should be present and should have the latest `text` value.")
+    }
+
+}


### PR DESCRIPTION
# Description

Correct behavior when writing an `AutocompleteManufacturer` model to perform `modelContext.save()` after an insert.

- There is a `@Attribute(.unique)` constraint on the `identifier: Int` field :)
- But when two models are created in quick succession, and not saved, then the uniqueness constraint is not enforced and the next save will fail :(

### Screenshots

| Before | After |
| -- | -- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2024-11-17 at 19 59 17](https://github.com/user-attachments/assets/3cd9b89e-4112-4324-a5cc-a2e82c9899d3) | ![Simulator Screen Recording - iPhone 16 Pro - 2024-11-17 at 19 36 36](https://github.com/user-attachments/assets/b5270db4-55c6-41d5-94ee-0f7411c548c3) |
