### PR TITLE
Fix: Add support for 2026 model bikes

### DIFF
--- a/BikeIndex/Model/Bike.swift
+++ b/BikeIndex/Model/Bike.swift
@@ -72,8 +72,8 @@ import MapKit
         /// The range of supported years for Bike models
         static let yearRange = 1900..<2100
 
-        /// The range of **displayable** years for Bike models aka "inclusive 1900-2025"
-        static let displayableYearRange = 1900..<2026
+        /// The range of **displayable** years for Bike models aka "inclusive 1900-2026"
+        static let displayableYearRange = 1900..<2027
     }
 
     init(identifier: Int,


### PR DESCRIPTION
# Description

- Add support for 2026 model-year bikes

### Screenshots

<img alt="Simulator Screenshot - iPhone 16 - 2025-01-01 at 11 42 24" src="https://github.com/user-attachments/assets/3ca98bd7-1352-482e-a055-f40b281d4688" width="50%">
