### PR TITLE
Fix: Convert Xcode project groups to folders 

### DIFF
--- a/BikeIndex.xcodeproj/project.pbxproj
+++ b/BikeIndex.xcodeproj/project.pbxproj
@@ -3,100 +3,20 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 71;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0401235E2B817BD50045FECE /* BikeIndexOrgApiV3Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A3E2B251E92006519A7 /* BikeIndexOrgApiV3Tests.swift */; };
-		0401235F2B817BD50045FECE /* BikeRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043033302B3E6FA100FD126F /* BikeRegistrationTests.swift */; };
-		040123612B817BD50045FECE /* Logger+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A3C2B251E91006519A7 /* Logger+Tests.swift */; };
-		040123622B817BD50045FECE /* UserRelationshipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A3D2B251E91006519A7 /* UserRelationshipTests.swift */; };
-		040123632B817BD50045FECE /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A3B2B251E91006519A7 /* UserTests.swift */; };
-		040123642B817BD50045FECE /* BikeModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B92E2B098B4F009442B5 /* BikeModelTests.swift */; };
-		040123652B817BD50045FECE /* OAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B92D2B098B4F009442B5 /* OAuthTests.swift */; };
-		040123662B817BF80045FECE /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A3F2B251E92006519A7 /* MockData.swift */; };
-		040FA32E2BCCB7F5000C4B18 /* ManufacturerKeyboardUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 040FA32D2BCCB7F5000C4B18 /* ManufacturerKeyboardUITestCase.swift */; };
-		041CCD8C2BC2E0D300A3A9A8 /* BikeRegistration+Propulsion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041CCD8B2BC2E0D300A3A9A8 /* BikeRegistration+Propulsion.swift */; };
-		041CCD8E2BC2E36300A3A9A8 /* RegistrationPropulsionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041CCD8D2BC2E36300A3A9A8 /* RegistrationPropulsionTests.swift */; };
-		043033282B3E285F00FD126F /* StolenRecordEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043033272B3E285F00FD126F /* StolenRecordEntryView.swift */; };
-		0430332A2B3E5EEB00FD126F /* Countries.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043033292B3E5EEB00FD126F /* Countries.swift */; };
-		0430332C2B3E642200FD126F /* Binding+Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0430332B2B3E642200FD126F /* Binding+Optional.swift */; };
-		0430332F2B3E64C300FD126F /* US_States.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0430332E2B3E64C300FD126F /* US_States.swift */; };
-		043033362B40C34800FD126F /* ContentButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043033352B40C34800FD126F /* ContentButtonView.swift */; };
-		043033382B41367100FD126F /* MainContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 043033372B41367100FD126F /* MainContent.swift */; };
-		0430333D2B41402800FD126F /* ProportionalLazyVGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0430333C2B41402800FD126F /* ProportionalLazyVGrid.swift */; };
-		0448501B2D18F8B500E41B1A /* MainContentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0448501A2D18F8B500E41B1A /* MainContentModel.swift */; };
-		0452C6B02B4A608E00AD572C /* AcknowledgementsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452C6AF2B4A608E00AD572C /* AcknowledgementsListView.swift */; };
-		0452C6B32B4A630500AD572C /* DebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452C6B22B4A630500AD572C /* DebugMenu.swift */; };
-		0452C6B62B4A64D800AD572C /* LicenseEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452C6B52B4A64D800AD572C /* LicenseEnum.swift */; };
-		0452C6BA2B4A72FD00AD572C /* AcknowledgementPackageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452C6B92B4A72FD00AD572C /* AcknowledgementPackageDetailView.swift */; };
-		0452C6BC2B4A7DFE00AD572C /* AcknowledgementPackage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0452C6BB2B4A7DFE00AD572C /* AcknowledgementPackage.swift */; };
-		046B0A372B251E58006519A7 /* AppIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A352B251E58006519A7 /* AppIconPicker.swift */; };
-		046B0A382B251E58006519A7 /* TextLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A362B251E58006519A7 /* TextLink.swift */; };
-		046B0A3A2B251E67006519A7 /* AlternateIconsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A392B251E67006519A7 /* AlternateIconsModel.swift */; };
-		046C5D452D1DEAD200002C55 /* MainContentModel+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046C5D442D1DEAD200002C55 /* MainContentModel+Error.swift */; };
-		04706F2D2CE99FF500C55831 /* ManufacturerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04706F2C2CE99FF500C55831 /* ManufacturerTests.swift */; };
-		0482AF1E2BCB59FE0077B0BF /* CameraCaptureButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0482AF1D2BCB59FE0077B0BF /* CameraCaptureButton.swift */; };
-		0485E9C72B9E2FA70071C48B /* Logger+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 046B0A3C2B251E91006519A7 /* Logger+Tests.swift */; };
-		0490A5EF2B26972600C4EC1E /* BikeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0490A5EE2B26972600C4EC1E /* BikeResponse.swift */; };
-		0490A5F12B269F7800C4EC1E /* AddBikeOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0490A5F02B269F7800C4EC1E /* AddBikeOutput.swift */; };
-		0494FD8C2B4250F70053C54F /* MainToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0494FD8B2B4250F70053C54F /* MainToolbar.swift */; };
-		049D347F2BB0DB8900E7F768 /* BicycleTypeSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 049D347E2BB0DB8900E7F768 /* BicycleTypeSelectionView.swift */; };
-		04A9DFB42D26117300DBDDD5 /* DebugDataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A9DFB32D26117300DBDDD5 /* DebugDataView.swift */; };
 		04ABEBB92D1F35B400E30577 /* PreviewGallery in Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBB82D1F35B400E30577 /* PreviewGallery */; };
 		04ABEBBB2D1F35B400E30577 /* SnapshotPreferences in Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBBA2D1F35B400E30577 /* SnapshotPreferences */; };
 		04ABEBBD2D1F35B400E30577 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBBC2D1F35B400E30577 /* SnapshottingTests */; };
-		04ABEBC02D1F370800E30577 /* BikeIndexAppPreviewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04ABEBBF2D1F370800E30577 /* BikeIndexAppPreviewTest.swift */; };
-		04ABEBC22D1F398300E30577 /* BikeIndexAppAccessibilityPreviewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04ABEBC12D1F398300E30577 /* BikeIndexAppAccessibilityPreviewTest.swift */; };
 		04ABEBC52D1F399E00E30577 /* Snapshotting in Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBC42D1F399E00E30577 /* Snapshotting */; };
 		04ABEBC62D1F399E00E30577 /* Snapshotting in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBC42D1F399E00E30577 /* Snapshotting */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		04ABEBC82D1F399E00E30577 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBC72D1F399E00E30577 /* SnapshottingTests */; };
-		04B660082B4309780055A056 /* AutocompleteManufacturerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B660072B4309780055A056 /* AutocompleteManufacturerResponse.swift */; };
-		04B6600B2B43169E0055A056 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B6600A2B43169E0055A056 /* WelcomeView.swift */; };
-		04C736EE2B8180FD00D2BDA3 /* ClientRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C736ED2B8180FD00D2BDA3 /* ClientRefreshTests.swift */; };
-		04C7BC642B534F090091493C /* PreviewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C7BC632B534F090091493C /* PreviewData.swift */; };
-		04C7BC702B535E330091493C /* BikeStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C7BC6F2B535E330091493C /* BikeStatus.swift */; };
-		04C7BC722B5361220091493C /* RegisterMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C7BC712B5361220091493C /* RegisterMode.swift */; };
-		04C7BC772B536C150091493C /* StolenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04C7BC762B536C150091493C /* StolenRecord.swift */; };
-		04CA5AE32D014CC800BD572A /* AuthenticatedUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CA5AE22D014CC800BD572A /* AuthenticatedUITestCase.swift */; };
 		04E1343E2B4B718200CE88DD /* WebViewKit in Frameworks */ = {isa = PBXBuildFile; productRef = 04E1343D2B4B718200CE88DD /* WebViewKit */; };
-		04EA110E2B2502660024CDDD /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EA110C2B2502660024CDDD /* API.swift */; };
-		04EA110F2B2502660024CDDD /* APIEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EA110D2B2502660024CDDD /* APIEndpoints.swift */; };
-		04EA11142B2502AF0024CDDD /* AuthenticatedUserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EA11122B2502AF0024CDDD /* AuthenticatedUserResponse.swift */; };
-		04EA11152B2502AF0024CDDD /* OAuthToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EA11132B2502AF0024CDDD /* OAuthToken.swift */; };
-		04EA11192B25039F0024CDDD /* BikeIndexIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EA11182B25039F0024CDDD /* BikeIndexIdentifiable.swift */; };
-		04EA111B2B2503B40024CDDD /* BikeRegisteredQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EA111A2B2503B40024CDDD /* BikeRegisteredQuery.swift */; };
-		04EA111D2B2503C40024CDDD /* BikeRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EA111C2B2503C40024CDDD /* BikeRegistration.swift */; };
 		04EA11222B2504340024CDDD /* URLEncodedForm in Frameworks */ = {isa = PBXBuildFile; productRef = 04EA11212B2504340024CDDD /* URLEncodedForm */; };
-		04EC712D2B5436BD00898CA1 /* AuthNavigationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EC712C2B5436BD00898CA1 /* AuthNavigationDelegate.swift */; };
-		04EC712F2B54414D00898CA1 /* WebScripts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EC712E2B54414D00898CA1 /* WebScripts.swift */; };
-		04EC71362B54B59500898CA1 /* NavigableWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EC71352B54B59500898CA1 /* NavigableWebView.swift */; };
-		04EC71382B54CB3900898CA1 /* NavigatorChild.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EC71372B54CB3900898CA1 /* NavigatorChild.swift */; };
-		04EC713C2B54CB8F00898CA1 /* HistoryNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EC713B2B54CB8F00898CA1 /* HistoryNavigator.swift */; };
-		04F2C63A2B4B00CD009E0A37 /* BikeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F2C6392B4B00CD009E0A37 /* BikeDetailView.swift */; };
-		04F2C63C2B4B0127009E0A37 /* ContentBikeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F2C63B2B4B0127009E0A37 /* ContentBikeButton.swift */; };
-		04F4B9012B098ADE009442B5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 04F4B9002B098ADE009442B5 /* Assets.xcassets */; };
-		04F4B9192B098ADE009442B5 /* BikeIndexUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B9182B098ADE009442B5 /* BikeIndexUITests.swift */; };
-		04F4B91B2B098ADE009442B5 /* BikeIndexUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B91A2B098ADE009442B5 /* BikeIndexUITestsLaunchTests.swift */; };
 		04F4B9322B098B5A009442B5 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 04F4B9312B098B5A009442B5 /* README.md */; };
-		04F4B9392B098B9C009442B5 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B9382B098B9C009442B5 /* Client.swift */; };
-		04F4B9422B098BAA009442B5 /* RegisterBikeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B93A2B098BA9009442B5 /* RegisterBikeView.swift */; };
-		04F4B9432B098BAA009442B5 /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B93B2B098BA9009442B5 /* AuthView.swift */; };
-		04F4B9442B098BAA009442B5 /* VerticalPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B93C2B098BA9009442B5 /* VerticalPicker.swift */; };
-		04F4B9452B098BAA009442B5 /* SearchBikesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B93D2B098BA9009442B5 /* SearchBikesView.swift */; };
-		04F4B9462B098BAA009442B5 /* ManufacturerEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B93E2B098BAA009442B5 /* ManufacturerEntryView.swift */; };
-		04F4B9482B098BAA009442B5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B9402B098BAA009442B5 /* SettingsView.swift */; };
-		04F4B9492B098BAA009442B5 /* MainContentPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B9412B098BAA009442B5 /* MainContentPage.swift */; };
-		04F4B9502B098BB1009442B5 /* Bike.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B94A2B098BB1009442B5 /* Bike.swift */; };
-		04F4B9512B098BB1009442B5 /* FrameColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B94B2B098BB1009442B5 /* FrameColor.swift */; };
-		04F4B9522B098BB1009442B5 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B94C2B098BB1009442B5 /* User.swift */; };
-		04F4B9542B098BB1009442B5 /* Manufacturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B94E2B098BB1009442B5 /* Manufacturer.swift */; };
-		04F4B9552B098BB1009442B5 /* BicycleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B94F2B098BB1009442B5 /* BicycleType.swift */; };
-		04F4B9592B098C11009442B5 /* BikeIndexApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B9582B098C11009442B5 /* BikeIndexApp.swift */; };
 		04F4B95E2B0990CE009442B5 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 04F4B95D2B0990CE009442B5 /* KeychainSwift */; };
-		04F4B9612B0996EC009442B5 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B9602B0996EC009442B5 /* Logger.swift */; };
-		04F4B9632B0998F6009442B5 /* ClientConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F4B9622B0998F6009442B5 /* ClientConfiguration.swift */; };
-		04FA3D632D02922700BF54E6 /* AcknowledgementRepositoryWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FA3D622D02922700BF54E6 /* AcknowledgementRepositoryWebView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,105 +51,64 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		040FA32D2BCCB7F5000C4B18 /* ManufacturerKeyboardUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManufacturerKeyboardUITestCase.swift; sourceTree = "<group>"; };
-		041CCD8B2BC2E0D300A3A9A8 /* BikeRegistration+Propulsion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BikeRegistration+Propulsion.swift"; sourceTree = "<group>"; };
-		041CCD8D2BC2E36300A3A9A8 /* RegistrationPropulsionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegistrationPropulsionTests.swift; sourceTree = "<group>"; };
-		043033272B3E285F00FD126F /* StolenRecordEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StolenRecordEntryView.swift; sourceTree = "<group>"; };
-		043033292B3E5EEB00FD126F /* Countries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Countries.swift; sourceTree = "<group>"; };
-		0430332B2B3E642200FD126F /* Binding+Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Binding+Optional.swift"; sourceTree = "<group>"; };
-		0430332E2B3E64C300FD126F /* US_States.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = US_States.swift; sourceTree = "<group>"; };
-		043033302B3E6FA100FD126F /* BikeRegistrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeRegistrationTests.swift; sourceTree = "<group>"; };
-		043033352B40C34800FD126F /* ContentButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentButtonView.swift; sourceTree = "<group>"; };
-		043033372B41367100FD126F /* MainContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContent.swift; sourceTree = "<group>"; };
-		0430333C2B41402800FD126F /* ProportionalLazyVGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProportionalLazyVGrid.swift; sourceTree = "<group>"; };
-		0448501A2D18F8B500E41B1A /* MainContentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContentModel.swift; sourceTree = "<group>"; };
-		0452C6AF2B4A608E00AD572C /* AcknowledgementsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementsListView.swift; sourceTree = "<group>"; };
-		0452C6B22B4A630500AD572C /* DebugMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugMenu.swift; sourceTree = "<group>"; };
-		0452C6B52B4A64D800AD572C /* LicenseEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseEnum.swift; sourceTree = "<group>"; };
-		0452C6B92B4A72FD00AD572C /* AcknowledgementPackageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementPackageDetailView.swift; sourceTree = "<group>"; };
-		0452C6BB2B4A7DFE00AD572C /* AcknowledgementPackage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementPackage.swift; sourceTree = "<group>"; };
-		046B0A352B251E58006519A7 /* AppIconPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppIconPicker.swift; sourceTree = "<group>"; };
-		046B0A362B251E58006519A7 /* TextLink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextLink.swift; sourceTree = "<group>"; };
-		046B0A392B251E67006519A7 /* AlternateIconsModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlternateIconsModel.swift; sourceTree = "<group>"; };
-		046B0A3B2B251E91006519A7 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
-		046B0A3C2B251E91006519A7 /* Logger+Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Logger+Tests.swift"; sourceTree = "<group>"; };
-		046B0A3D2B251E91006519A7 /* UserRelationshipTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserRelationshipTests.swift; sourceTree = "<group>"; };
-		046B0A3E2B251E92006519A7 /* BikeIndexOrgApiV3Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BikeIndexOrgApiV3Tests.swift; sourceTree = "<group>"; };
-		046B0A3F2B251E92006519A7 /* MockData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
-		046C5D442D1DEAD200002C55 /* MainContentModel+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainContentModel+Error.swift"; sourceTree = "<group>"; };
-		04706F2C2CE99FF500C55831 /* ManufacturerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManufacturerTests.swift; sourceTree = "<group>"; };
-		0482AF1D2BCB59FE0077B0BF /* CameraCaptureButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCaptureButton.swift; sourceTree = "<group>"; };
-		0490A5EE2B26972600C4EC1E /* BikeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeResponse.swift; sourceTree = "<group>"; };
-		0490A5F02B269F7800C4EC1E /* AddBikeOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddBikeOutput.swift; sourceTree = "<group>"; };
-		0494FD8B2B4250F70053C54F /* MainToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainToolbar.swift; sourceTree = "<group>"; };
 		0496C6702CB36BED00B88D1B /* Brewfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Brewfile; sourceTree = "<group>"; };
 		0496C6712CB36BF100B88D1B /* .ruby-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".ruby-version"; sourceTree = "<group>"; };
 		0496C6722CB36BF600B88D1B /* Gemfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Gemfile; sourceTree = "<group>"; };
-		049D347E2BB0DB8900E7F768 /* BicycleTypeSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BicycleTypeSelectionView.swift; sourceTree = "<group>"; };
-		04A9DFB32D26117300DBDDD5 /* DebugDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDataView.swift; sourceTree = "<group>"; };
-		04ABEBBE2D1F360E00E30577 /* Debug (bikeindex.org).xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Debug (bikeindex.org).xctestplan"; sourceTree = "<group>"; };
-		04ABEBBF2D1F370800E30577 /* BikeIndexAppPreviewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeIndexAppPreviewTest.swift; sourceTree = "<group>"; };
-		04ABEBC12D1F398300E30577 /* BikeIndexAppAccessibilityPreviewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeIndexAppAccessibilityPreviewTest.swift; sourceTree = "<group>"; };
-		04B660072B4309780055A056 /* AutocompleteManufacturerResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocompleteManufacturerResponse.swift; sourceTree = "<group>"; };
-		04B6600A2B43169E0055A056 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
-		04C736EC2B817FDC00D2BDA3 /* AllTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = AllTests.xctestplan; sourceTree = "<group>"; };
-		04C736ED2B8180FD00D2BDA3 /* ClientRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientRefreshTests.swift; sourceTree = "<group>"; };
-		04C7BC632B534F090091493C /* PreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewData.swift; sourceTree = "<group>"; };
-		04C7BC652B53514C0091493C /* SingleBikeResponse_mock.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = SingleBikeResponse_mock.json; sourceTree = "<group>"; };
-		04C7BC6F2B535E330091493C /* BikeStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeStatus.swift; sourceTree = "<group>"; };
-		04C7BC712B5361220091493C /* RegisterMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterMode.swift; sourceTree = "<group>"; };
-		04C7BC762B536C150091493C /* StolenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StolenRecord.swift; sourceTree = "<group>"; };
-		04CA5AD92D013A5400BD572A /* Test-credentials.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Test-credentials.xcconfig"; sourceTree = "<group>"; };
-		04CA5ADC2D013A7200BD572A /* Test-credentials-template.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Test-credentials-template.xcconfig"; sourceTree = "<group>"; };
-		04CA5AE02D013BAA00BD572A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		04CA5AE22D014CC800BD572A /* AuthenticatedUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedUITestCase.swift; sourceTree = "<group>"; };
-		04EA110C2B2502660024CDDD /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
-		04EA110D2B2502660024CDDD /* APIEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoints.swift; sourceTree = "<group>"; };
-		04EA11122B2502AF0024CDDD /* AuthenticatedUserResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthenticatedUserResponse.swift; sourceTree = "<group>"; };
-		04EA11132B2502AF0024CDDD /* OAuthToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthToken.swift; sourceTree = "<group>"; };
-		04EA11182B25039F0024CDDD /* BikeIndexIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BikeIndexIdentifiable.swift; sourceTree = "<group>"; };
-		04EA111A2B2503B40024CDDD /* BikeRegisteredQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BikeRegisteredQuery.swift; sourceTree = "<group>"; };
-		04EA111C2B2503C40024CDDD /* BikeRegistration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BikeRegistration.swift; sourceTree = "<group>"; };
-		04EC712C2B5436BD00898CA1 /* AuthNavigationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthNavigationDelegate.swift; sourceTree = "<group>"; };
-		04EC712E2B54414D00898CA1 /* WebScripts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebScripts.swift; sourceTree = "<group>"; };
-		04EC71352B54B59500898CA1 /* NavigableWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigableWebView.swift; sourceTree = "<group>"; };
-		04EC71372B54CB3900898CA1 /* NavigatorChild.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigatorChild.swift; sourceTree = "<group>"; };
-		04EC713B2B54CB8F00898CA1 /* HistoryNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryNavigator.swift; sourceTree = "<group>"; };
-		04F2C6392B4B00CD009E0A37 /* BikeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeDetailView.swift; sourceTree = "<group>"; };
-		04F2C63B2B4B0127009E0A37 /* ContentBikeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentBikeButton.swift; sourceTree = "<group>"; };
 		04F4B8F72B098ADB009442B5 /* BikeIndex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BikeIndex.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		04F4B9002B098ADE009442B5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		04F4B9022B098ADE009442B5 /* BikeIndex.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BikeIndex.entitlements; sourceTree = "<group>"; };
-		04F4B9042B098ADE009442B5 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		04F4B90A2B098ADE009442B5 /* BikeIndexTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BikeIndexTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		04F4B9142B098ADE009442B5 /* BikeIndexUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BikeIndexUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		04F4B9182B098ADE009442B5 /* BikeIndexUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeIndexUITests.swift; sourceTree = "<group>"; };
-		04F4B91A2B098ADE009442B5 /* BikeIndexUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BikeIndexUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		04F4B9272B098B44009442B5 /* BikeIndex-production.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "BikeIndex-production.xcconfig"; sourceTree = "<group>"; };
 		04F4B9282B098B44009442B5 /* BikeIndex-template.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "BikeIndex-template.xcconfig"; sourceTree = "<group>"; };
 		04F4B9292B098B44009442B5 /* BikeIndex-development.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "BikeIndex-development.xcconfig"; sourceTree = "<group>"; };
-		04F4B92D2B098B4F009442B5 /* OAuthTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OAuthTests.swift; sourceTree = "<group>"; };
-		04F4B92E2B098B4F009442B5 /* BikeModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BikeModelTests.swift; sourceTree = "<group>"; };
 		04F4B9312B098B5A009442B5 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		04F4B9382B098B9C009442B5 /* Client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
-		04F4B93A2B098BA9009442B5 /* RegisterBikeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegisterBikeView.swift; sourceTree = "<group>"; };
-		04F4B93B2B098BA9009442B5 /* AuthView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
-		04F4B93C2B098BA9009442B5 /* VerticalPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalPicker.swift; sourceTree = "<group>"; };
-		04F4B93D2B098BA9009442B5 /* SearchBikesView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchBikesView.swift; sourceTree = "<group>"; };
-		04F4B93E2B098BAA009442B5 /* ManufacturerEntryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ManufacturerEntryView.swift; sourceTree = "<group>"; };
-		04F4B9402B098BAA009442B5 /* SettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		04F4B9412B098BAA009442B5 /* MainContentPage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainContentPage.swift; sourceTree = "<group>"; };
-		04F4B94A2B098BB1009442B5 /* Bike.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bike.swift; sourceTree = "<group>"; };
-		04F4B94B2B098BB1009442B5 /* FrameColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrameColor.swift; sourceTree = "<group>"; };
-		04F4B94C2B098BB1009442B5 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
-		04F4B94E2B098BB1009442B5 /* Manufacturer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Manufacturer.swift; sourceTree = "<group>"; };
-		04F4B94F2B098BB1009442B5 /* BicycleType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BicycleType.swift; sourceTree = "<group>"; };
-		04F4B9582B098C11009442B5 /* BikeIndexApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BikeIndexApp.swift; sourceTree = "<group>"; };
-		04F4B95A2B098C3C009442B5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		04F4B9602B0996EC009442B5 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
-		04F4B9622B0998F6009442B5 /* ClientConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientConfiguration.swift; sourceTree = "<group>"; };
-		04FA3D622D02922700BF54E6 /* AcknowledgementRepositoryWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcknowledgementRepositoryWebView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		04CDF1442D3C344100F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+				"Preview Content/Preview Assets.xcassets",
+				"Preview Content/SingleBikeResponse_mock.json",
+			);
+			target = 04F4B8F62B098ADB009442B5 /* BikeIndex */;
+		};
+		04CDF15C2D3C344500F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Debug (bikeindex.org).xctestplan",
+			);
+			target = 04F4B9092B098ADE009442B5 /* BikeIndexTests */;
+		};
+		04CDF16A2D3C344800F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 04F4B9132B098ADE009442B5 /* BikeIndexUITests */;
+		};
+		04CDF1722D3C344C00F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Logger+Tests.swift",
+			);
+			target = 04F4B9092B098ADE009442B5 /* BikeIndexTests */;
+		};
+		04CDF1732D3C344C00F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Logger+Tests.swift",
+			);
+			target = 04F4B9132B098ADE009442B5 /* BikeIndexUITests */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		04CDF1012D3C344100F90515 /* BikeIndex */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (04CDF1442D3C344100F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BikeIndex; sourceTree = "<group>"; };
+		04CDF1502D3C344500F90515 /* BikeIndexTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (04CDF15C2D3C344500F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BikeIndexTests; sourceTree = "<group>"; };
+		04CDF1632D3C344800F90515 /* BikeIndexUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (04CDF16A2D3C344800F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = BikeIndexUITests; sourceTree = "<group>"; };
+		04CDF16F2D3C344C00F90515 /* SharedTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (04CDF1722D3C344C00F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 04CDF1732D3C344C00F90515 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SharedTests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		04F4B8F42B098ADB009442B5 /* Frameworks */ = {
@@ -264,168 +143,11 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0430332D2B3E64B900FD126F /* Regions */ = {
-			isa = PBXGroup;
-			children = (
-				043033292B3E5EEB00FD126F /* Countries.swift */,
-				0430332E2B3E64C300FD126F /* US_States.swift */,
-			);
-			path = Regions;
-			sourceTree = "<group>";
-		};
-		043033342B40C32600FD126F /* MainContent */ = {
-			isa = PBXGroup;
-			children = (
-				04F4B9412B098BAA009442B5 /* MainContentPage.swift */,
-				043033352B40C34800FD126F /* ContentButtonView.swift */,
-				04F2C63B2B4B0127009E0A37 /* ContentBikeButton.swift */,
-				0494FD8B2B4250F70053C54F /* MainToolbar.swift */,
-			);
-			path = MainContent;
-			sourceTree = "<group>";
-		};
-		0448501C2D18F8CA00E41B1A /* MainContent */ = {
-			isa = PBXGroup;
-			children = (
-				0448501A2D18F8B500E41B1A /* MainContentModel.swift */,
-				046C5D442D1DEAD200002C55 /* MainContentModel+Error.swift */,
-			);
-			path = MainContent;
-			sourceTree = "<group>";
-		};
-		0452C6B12B4A62FE00AD572C /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				04F4B9402B098BAA009442B5 /* SettingsView.swift */,
-				046B0A352B251E58006519A7 /* AppIconPicker.swift */,
-				0452C6B22B4A630500AD572C /* DebugMenu.swift */,
-				0452C6AF2B4A608E00AD572C /* AcknowledgementsListView.swift */,
-				0452C6B92B4A72FD00AD572C /* AcknowledgementPackageDetailView.swift */,
-				04FA3D622D02922700BF54E6 /* AcknowledgementRepositoryWebView.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
-		0452C6B42B4A64C200AD572C /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				0452C6B52B4A64D800AD572C /* LicenseEnum.swift */,
-				0452C6BB2B4A7DFE00AD572C /* AcknowledgementPackage.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
-		0453EA312B3CB06500FBF74C /* Navigation */ = {
-			isa = PBXGroup;
-			children = (
-				043033372B41367100FD126F /* MainContent.swift */,
-			);
-			path = Navigation;
-			sourceTree = "<group>";
-		};
-		0482AF1C2BCB59ED0077B0BF /* Camera */ = {
-			isa = PBXGroup;
-			children = (
-				0482AF1D2BCB59FE0077B0BF /* CameraCaptureButton.swift */,
-			);
-			path = Camera;
-			sourceTree = "<group>";
-		};
-		0485E9C82B9E2FAE0071C48B /* SharedTests */ = {
-			isa = PBXGroup;
-			children = (
-				04C736EC2B817FDC00D2BDA3 /* AllTests.xctestplan */,
-				046B0A3C2B251E91006519A7 /* Logger+Tests.swift */,
-				04CA5AD92D013A5400BD572A /* Test-credentials.xcconfig */,
-				04CA5ADC2D013A7200BD572A /* Test-credentials-template.xcconfig */,
-			);
-			path = SharedTests;
-			sourceTree = "<group>";
-		};
-		04A9DFB22D26116200DBDDD5 /* Debug */ = {
-			isa = PBXGroup;
-			children = (
-				04A9DFB32D26117300DBDDD5 /* DebugDataView.swift */,
-			);
-			path = Debug;
-			sourceTree = "<group>";
-		};
 		04ABEBC32D1F399E00E30577 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		04B660062B4309630055A056 /* Manufacturer */ = {
-			isa = PBXGroup;
-			children = (
-				04F4B94E2B098BB1009442B5 /* Manufacturer.swift */,
-				04B660072B4309780055A056 /* AutocompleteManufacturerResponse.swift */,
-			);
-			path = Manufacturer;
-			sourceTree = "<group>";
-		};
-		04B660092B4316970055A056 /* Onboarding */ = {
-			isa = PBXGroup;
-			children = (
-				04F4B93B2B098BA9009442B5 /* AuthView.swift */,
-				04B6600A2B43169E0055A056 /* WelcomeView.swift */,
-			);
-			path = Onboarding;
-			sourceTree = "<group>";
-		};
-		04C7BC6C2B535DE60091493C /* Registering */ = {
-			isa = PBXGroup;
-			children = (
-				04EA111C2B2503C40024CDDD /* BikeRegistration.swift */,
-				04C7BC762B536C150091493C /* StolenRecord.swift */,
-				04EA111A2B2503B40024CDDD /* BikeRegisteredQuery.swift */,
-				0490A5F02B269F7800C4EC1E /* AddBikeOutput.swift */,
-				04C7BC712B5361220091493C /* RegisterMode.swift */,
-				041CCD8B2BC2E0D300A3A9A8 /* BikeRegistration+Propulsion.swift */,
-			);
-			path = Registering;
-			sourceTree = "<group>";
-		};
-		04EA11112B2502990024CDDD /* Authentication */ = {
-			isa = PBXGroup;
-			children = (
-				04EA11122B2502AF0024CDDD /* AuthenticatedUserResponse.swift */,
-				04EA11132B2502AF0024CDDD /* OAuthToken.swift */,
-			);
-			path = Authentication;
-			sourceTree = "<group>";
-		};
-		04EC71292B54362700898CA1 /* Web */ = {
-			isa = PBXGroup;
-			children = (
-				04EC712C2B5436BD00898CA1 /* AuthNavigationDelegate.swift */,
-				04EC71372B54CB3900898CA1 /* NavigatorChild.swift */,
-				04EC713B2B54CB8F00898CA1 /* HistoryNavigator.swift */,
-				04EC712E2B54414D00898CA1 /* WebScripts.swift */,
-				04EC71352B54B59500898CA1 /* NavigableWebView.swift */,
-			);
-			path = Web;
-			sourceTree = "<group>";
-		};
-		04F2C6372B4B0079009E0A37 /* Registering */ = {
-			isa = PBXGroup;
-			children = (
-				043033272B3E285F00FD126F /* StolenRecordEntryView.swift */,
-				04F4B93A2B098BA9009442B5 /* RegisterBikeView.swift */,
-				04F4B93E2B098BAA009442B5 /* ManufacturerEntryView.swift */,
-				049D347E2BB0DB8900E7F768 /* BicycleTypeSelectionView.swift */,
-			);
-			path = Registering;
-			sourceTree = "<group>";
-		};
-		04F2C6382B4B00B0009E0A37 /* BikeDetail */ = {
-			isa = PBXGroup;
-			children = (
-				04F2C6392B4B00CD009E0A37 /* BikeDetailView.swift */,
-			);
-			path = BikeDetail;
 			sourceTree = "<group>";
 		};
 		04F4B8EE2B098ADB009442B5 = {
@@ -435,10 +157,10 @@
 				04F4B9292B098B44009442B5 /* BikeIndex-development.xcconfig */,
 				04F4B9272B098B44009442B5 /* BikeIndex-production.xcconfig */,
 				04F4B9282B098B44009442B5 /* BikeIndex-template.xcconfig */,
-				04F4B8F92B098ADB009442B5 /* BikeIndex */,
-				04F4B90D2B098ADE009442B5 /* BikeIndexTests */,
-				04F4B9172B098ADE009442B5 /* BikeIndexUITests */,
-				0485E9C82B9E2FAE0071C48B /* SharedTests */,
+				04CDF1012D3C344100F90515 /* BikeIndex */,
+				04CDF1502D3C344500F90515 /* BikeIndexTests */,
+				04CDF1632D3C344800F90515 /* BikeIndexUITests */,
+				04CDF16F2D3C344C00F90515 /* SharedTests */,
 				0496C6702CB36BED00B88D1B /* Brewfile */,
 				0496C6722CB36BF600B88D1B /* Gemfile */,
 				0496C6712CB36BF100B88D1B /* .ruby-version */,
@@ -457,125 +179,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		04F4B8F92B098ADB009442B5 /* BikeIndex */ = {
-			isa = PBXGroup;
-			children = (
-				04F4B9582B098C11009442B5 /* BikeIndexApp.swift */,
-				04F4B9372B098B9C009442B5 /* API */,
-				04F4B9362B098B81009442B5 /* View */,
-				04F4B9352B098B73009442B5 /* Model */,
-				04F4B95F2B0996E3009442B5 /* Utility */,
-				04F4B95A2B098C3C009442B5 /* Info.plist */,
-				04F4B9002B098ADE009442B5 /* Assets.xcassets */,
-				04F4B9022B098ADE009442B5 /* BikeIndex.entitlements */,
-				04C7BC632B534F090091493C /* PreviewData.swift */,
-				04F4B9032B098ADE009442B5 /* Preview Content */,
-			);
-			path = BikeIndex;
-			sourceTree = "<group>";
-		};
-		04F4B9032B098ADE009442B5 /* Preview Content */ = {
-			isa = PBXGroup;
-			children = (
-				04F4B9042B098ADE009442B5 /* Preview Assets.xcassets */,
-				04C7BC652B53514C0091493C /* SingleBikeResponse_mock.json */,
-			);
-			path = "Preview Content";
-			sourceTree = "<group>";
-		};
-		04F4B90D2B098ADE009442B5 /* BikeIndexTests */ = {
-			isa = PBXGroup;
-			children = (
-				04ABEBBE2D1F360E00E30577 /* Debug (bikeindex.org).xctestplan */,
-				046B0A3E2B251E92006519A7 /* BikeIndexOrgApiV3Tests.swift */,
-				046B0A3D2B251E91006519A7 /* UserRelationshipTests.swift */,
-				04706F2C2CE99FF500C55831 /* ManufacturerTests.swift */,
-				046B0A3B2B251E91006519A7 /* UserTests.swift */,
-				04F4B92E2B098B4F009442B5 /* BikeModelTests.swift */,
-				043033302B3E6FA100FD126F /* BikeRegistrationTests.swift */,
-				04F4B92D2B098B4F009442B5 /* OAuthTests.swift */,
-				04C736ED2B8180FD00D2BDA3 /* ClientRefreshTests.swift */,
-				041CCD8D2BC2E36300A3A9A8 /* RegistrationPropulsionTests.swift */,
-				04ABEBBF2D1F370800E30577 /* BikeIndexAppPreviewTest.swift */,
-			);
-			path = BikeIndexTests;
-			sourceTree = "<group>";
-		};
-		04F4B9172B098ADE009442B5 /* BikeIndexUITests */ = {
-			isa = PBXGroup;
-			children = (
-				04ABEBC12D1F398300E30577 /* BikeIndexAppAccessibilityPreviewTest.swift */,
-				04CA5AE02D013BAA00BD572A /* Info.plist */,
-				04F4B9182B098ADE009442B5 /* BikeIndexUITests.swift */,
-				04CA5AE22D014CC800BD572A /* AuthenticatedUITestCase.swift */,
-				040FA32D2BCCB7F5000C4B18 /* ManufacturerKeyboardUITestCase.swift */,
-				04F4B91A2B098ADE009442B5 /* BikeIndexUITestsLaunchTests.swift */,
-			);
-			path = BikeIndexUITests;
-			sourceTree = "<group>";
-		};
-		04F4B9352B098B73009442B5 /* Model */ = {
-			isa = PBXGroup;
-			children = (
-				0448501C2D18F8CA00E41B1A /* MainContent */,
-				046B0A3F2B251E92006519A7 /* MockData.swift */,
-				0452C6B42B4A64C200AD572C /* Settings */,
-				0453EA312B3CB06500FBF74C /* Navigation */,
-				046B0A392B251E67006519A7 /* AlternateIconsModel.swift */,
-				04C7BC6C2B535DE60091493C /* Registering */,
-				04EA11182B25039F0024CDDD /* BikeIndexIdentifiable.swift */,
-				04EA11112B2502990024CDDD /* Authentication */,
-				04F4B94F2B098BB1009442B5 /* BicycleType.swift */,
-				04F4B94A2B098BB1009442B5 /* Bike.swift */,
-				04C7BC6F2B535E330091493C /* BikeStatus.swift */,
-				04F4B94B2B098BB1009442B5 /* FrameColor.swift */,
-				04B660062B4309630055A056 /* Manufacturer */,
-				04F4B94C2B098BB1009442B5 /* User.swift */,
-				0490A5EE2B26972600C4EC1E /* BikeResponse.swift */,
-				0430332D2B3E64B900FD126F /* Regions */,
-			);
-			path = Model;
-			sourceTree = "<group>";
-		};
-		04F4B9362B098B81009442B5 /* View */ = {
-			isa = PBXGroup;
-			children = (
-				0482AF1C2BCB59ED0077B0BF /* Camera */,
-				04EC71292B54362700898CA1 /* Web */,
-				04F2C6382B4B00B0009E0A37 /* BikeDetail */,
-				046B0A362B251E58006519A7 /* TextLink.swift */,
-				04F2C6372B4B0079009E0A37 /* Registering */,
-				04B660092B4316970055A056 /* Onboarding */,
-				043033342B40C32600FD126F /* MainContent */,
-				04F4B93D2B098BA9009442B5 /* SearchBikesView.swift */,
-				0452C6B12B4A62FE00AD572C /* Settings */,
-				04F4B93C2B098BA9009442B5 /* VerticalPicker.swift */,
-				0430333C2B41402800FD126F /* ProportionalLazyVGrid.swift */,
-				04A9DFB22D26116200DBDDD5 /* Debug */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
-		04F4B9372B098B9C009442B5 /* API */ = {
-			isa = PBXGroup;
-			children = (
-				04EA110C2B2502660024CDDD /* API.swift */,
-				04EA110D2B2502660024CDDD /* APIEndpoints.swift */,
-				04F4B9382B098B9C009442B5 /* Client.swift */,
-				04F4B9622B0998F6009442B5 /* ClientConfiguration.swift */,
-			);
-			path = API;
-			sourceTree = "<group>";
-		};
-		04F4B95F2B0996E3009442B5 /* Utility */ = {
-			isa = PBXGroup;
-			children = (
-				04F4B9602B0996EC009442B5 /* Logger.swift */,
-				0430332B2B3E642200FD126F /* Binding+Optional.swift */,
-			);
-			path = Utility;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -590,6 +193,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				04CDF1012D3C344100F90515 /* BikeIndex */,
 			);
 			name = BikeIndex;
 			packageProductDependencies = (
@@ -616,6 +222,9 @@
 			dependencies = (
 				04F4B90C2B098ADE009442B5 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				04CDF1502D3C344500F90515 /* BikeIndexTests */,
+			);
 			name = BikeIndexTests;
 			productName = BikeIndexTests;
 			productReference = 04F4B90A2B098ADE009442B5 /* BikeIndexTests.xctest */;
@@ -634,6 +243,9 @@
 			);
 			dependencies = (
 				04F4B9162B098ADE009442B5 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				04CDF1632D3C344800F90515 /* BikeIndexUITests */,
 			);
 			name = BikeIndexUITests;
 			productName = BikeIndexUITests;
@@ -694,7 +306,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				04F4B9012B098ADE009442B5 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -720,68 +331,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				04F4B9542B098BB1009442B5 /* Manufacturer.swift in Sources */,
-				04F4B9492B098BAA009442B5 /* MainContentPage.swift in Sources */,
-				0430333D2B41402800FD126F /* ProportionalLazyVGrid.swift in Sources */,
-				04F4B9432B098BAA009442B5 /* AuthView.swift in Sources */,
-				04EA111B2B2503B40024CDDD /* BikeRegisteredQuery.swift in Sources */,
-				040123662B817BF80045FECE /* MockData.swift in Sources */,
-				04F4B9442B098BAA009442B5 /* VerticalPicker.swift in Sources */,
-				04EC712F2B54414D00898CA1 /* WebScripts.swift in Sources */,
-				0430332C2B3E642200FD126F /* Binding+Optional.swift in Sources */,
-				04C7BC642B534F090091493C /* PreviewData.swift in Sources */,
-				04B6600B2B43169E0055A056 /* WelcomeView.swift in Sources */,
-				041CCD8C2BC2E0D300A3A9A8 /* BikeRegistration+Propulsion.swift in Sources */,
-				04EC71362B54B59500898CA1 /* NavigableWebView.swift in Sources */,
-				04F4B9422B098BAA009442B5 /* RegisterBikeView.swift in Sources */,
-				0430332F2B3E64C300FD126F /* US_States.swift in Sources */,
-				0430332A2B3E5EEB00FD126F /* Countries.swift in Sources */,
-				04F2C63A2B4B00CD009E0A37 /* BikeDetailView.swift in Sources */,
-				0448501B2D18F8B500E41B1A /* MainContentModel.swift in Sources */,
-				0490A5F12B269F7800C4EC1E /* AddBikeOutput.swift in Sources */,
-				04F4B9392B098B9C009442B5 /* Client.swift in Sources */,
-				04A9DFB42D26117300DBDDD5 /* DebugDataView.swift in Sources */,
-				04FA3D632D02922700BF54E6 /* AcknowledgementRepositoryWebView.swift in Sources */,
-				04C7BC772B536C150091493C /* StolenRecord.swift in Sources */,
-				043033362B40C34800FD126F /* ContentButtonView.swift in Sources */,
-				046B0A372B251E58006519A7 /* AppIconPicker.swift in Sources */,
-				04EC713C2B54CB8F00898CA1 /* HistoryNavigator.swift in Sources */,
-				04F4B9612B0996EC009442B5 /* Logger.swift in Sources */,
-				04EA11192B25039F0024CDDD /* BikeIndexIdentifiable.swift in Sources */,
-				046B0A382B251E58006519A7 /* TextLink.swift in Sources */,
-				0490A5EF2B26972600C4EC1E /* BikeResponse.swift in Sources */,
-				04F4B9522B098BB1009442B5 /* User.swift in Sources */,
-				0452C6BC2B4A7DFE00AD572C /* AcknowledgementPackage.swift in Sources */,
-				0452C6B02B4A608E00AD572C /* AcknowledgementsListView.swift in Sources */,
-				0452C6B32B4A630500AD572C /* DebugMenu.swift in Sources */,
-				04F4B9512B098BB1009442B5 /* FrameColor.swift in Sources */,
-				04F4B9452B098BAA009442B5 /* SearchBikesView.swift in Sources */,
-				04C7BC702B535E330091493C /* BikeStatus.swift in Sources */,
-				043033282B3E285F00FD126F /* StolenRecordEntryView.swift in Sources */,
-				043033382B41367100FD126F /* MainContent.swift in Sources */,
-				046B0A3A2B251E67006519A7 /* AlternateIconsModel.swift in Sources */,
-				0452C6BA2B4A72FD00AD572C /* AcknowledgementPackageDetailView.swift in Sources */,
-				0494FD8C2B4250F70053C54F /* MainToolbar.swift in Sources */,
-				04EA110F2B2502660024CDDD /* APIEndpoints.swift in Sources */,
-				04F2C63C2B4B0127009E0A37 /* ContentBikeButton.swift in Sources */,
-				04C7BC722B5361220091493C /* RegisterMode.swift in Sources */,
-				04EA111D2B2503C40024CDDD /* BikeRegistration.swift in Sources */,
-				0452C6B62B4A64D800AD572C /* LicenseEnum.swift in Sources */,
-				04EC712D2B5436BD00898CA1 /* AuthNavigationDelegate.swift in Sources */,
-				04F4B9462B098BAA009442B5 /* ManufacturerEntryView.swift in Sources */,
-				04F4B9482B098BAA009442B5 /* SettingsView.swift in Sources */,
-				04EC71382B54CB3900898CA1 /* NavigatorChild.swift in Sources */,
-				04EA11152B2502AF0024CDDD /* OAuthToken.swift in Sources */,
-				04F4B9592B098C11009442B5 /* BikeIndexApp.swift in Sources */,
-				04F4B9502B098BB1009442B5 /* Bike.swift in Sources */,
-				046C5D452D1DEAD200002C55 /* MainContentModel+Error.swift in Sources */,
-				0482AF1E2BCB59FE0077B0BF /* CameraCaptureButton.swift in Sources */,
-				04F4B9632B0998F6009442B5 /* ClientConfiguration.swift in Sources */,
-				04B660082B4309780055A056 /* AutocompleteManufacturerResponse.swift in Sources */,
-				04EA110E2B2502660024CDDD /* API.swift in Sources */,
-				04F4B9552B098BB1009442B5 /* BicycleType.swift in Sources */,
-				04EA11142B2502AF0024CDDD /* AuthenticatedUserResponse.swift in Sources */,
-				049D347F2BB0DB8900E7F768 /* BicycleTypeSelectionView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -789,17 +338,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				040123632B817BD50045FECE /* UserTests.swift in Sources */,
-				041CCD8E2BC2E36300A3A9A8 /* RegistrationPropulsionTests.swift in Sources */,
-				040123642B817BD50045FECE /* BikeModelTests.swift in Sources */,
-				04ABEBC02D1F370800E30577 /* BikeIndexAppPreviewTest.swift in Sources */,
-				0401235E2B817BD50045FECE /* BikeIndexOrgApiV3Tests.swift in Sources */,
-				0401235F2B817BD50045FECE /* BikeRegistrationTests.swift in Sources */,
-				04C736EE2B8180FD00D2BDA3 /* ClientRefreshTests.swift in Sources */,
-				04706F2D2CE99FF500C55831 /* ManufacturerTests.swift in Sources */,
-				040123622B817BD50045FECE /* UserRelationshipTests.swift in Sources */,
-				040123612B817BD50045FECE /* Logger+Tests.swift in Sources */,
-				040123652B817BD50045FECE /* OAuthTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -807,12 +345,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				04F4B91B2B098ADE009442B5 /* BikeIndexUITestsLaunchTests.swift in Sources */,
-				0485E9C72B9E2FA70071C48B /* Logger+Tests.swift in Sources */,
-				04ABEBC22D1F398300E30577 /* BikeIndexAppAccessibilityPreviewTest.swift in Sources */,
-				04CA5AE32D014CC800BD572A /* AuthenticatedUITestCase.swift in Sources */,
-				04F4B9192B098ADE009442B5 /* BikeIndexUITests.swift in Sources */,
-				040FA32E2BCCB7F5000C4B18 /* ManufacturerKeyboardUITestCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -960,7 +492,8 @@
 		};
 		04EA11262B25135D0024CDDD /* Debug BikeIndex.org */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04CA5AD92D013A5400BD572A /* Test-credentials.xcconfig */;
+			baseConfigurationReferenceAnchor = 04CDF16F2D3C344C00F90515 /* SharedTests */;
+			baseConfigurationReferenceRelativePath = "Test-credentials.xcconfig";
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1226,7 +759,8 @@
 		};
 		04F4B9252B098ADE009442B5 /* Debug (development) */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04CA5AD92D013A5400BD572A /* Test-credentials.xcconfig */;
+			baseConfigurationReferenceAnchor = 04CDF16F2D3C344C00F90515 /* SharedTests */;
+			baseConfigurationReferenceRelativePath = "Test-credentials.xcconfig";
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1248,7 +782,8 @@
 		};
 		04F4B9262B098ADE009442B5 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 04CA5AD92D013A5400BD572A /* Test-credentials.xcconfig */;
+			baseConfigurationReferenceAnchor = 04CDF16F2D3C344C00F90515 /* SharedTests */;
+			baseConfigurationReferenceRelativePath = "Test-credentials.xcconfig";
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
# Description

> There are several benefits to using folders instead of groups when organizing your Xcode project files. Folders have a much smaller representation in the project file, which can result in fewer merge conflicts because when you add or remove files to the project you don’t modify the project file. Additionally, your Xcode project file automatically updates as you make changes to the file system.
-- https://developer.apple.com/documentation/xcode/managing-files-and-folders-in-your-xcode-project#Convert-groups-to-folders

Still using Xcode 16.0 at this time.