### PR TITLE
Fix: Try adding merge_group to workflow to opt-in to status checks

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  merge_groups:
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_groups:
 
 jobs:
   build:


### PR DESCRIPTION
# Description

- I want to enable GitHub's Auto-merge: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request
- To enable this,
    - First the workflows must appear in the Settings > Rulesets > Require status checks to pass > Add checks UI
    - At this time no workflows appear there
- Following the docs at https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#status-checks-with-github-actions-and-a-merge-queue
    - This _implies_ that `on: merge_group:` must be active in the GitHub Action workflow to troubleshoot required status checks not appearing. But it likely is just for merge queues and not "auto-merge".
    - Community discussions have added GitHub Actions to fix a gap which is that skipped checks are marked as successful which is a false-positive.
    - https://github.com/orgs/community/discussions/26733
    - https://github.com/orgs/community/discussions/26668