### PR TITLE
Fix: Display app version in Settings

### DIFF
--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -56,7 +56,7 @@ struct MainContentPage: View {
             .navigationDestination(for: MainContent.self) { selection in
                 switch selection {
                 case .settings:
-                    SettingsView(path: $path)
+                    SettingsPage(path: $path)
                         .accessibilityIdentifier("Settings")
                 case .registerBike:
                     RegisterBikeView(mode: .myOwnBike)

--- a/BikeIndex/View/Onboarding/AuthView.swift
+++ b/BikeIndex/View/Onboarding/AuthView.swift
@@ -82,7 +82,7 @@ struct AuthView: View {
             .navigationDestination(for: Nav.self) { navSelection in
                 switch navSelection {
                 case .debugSettings:
-                    SettingsView(path: $path)
+                    SettingsPage(path: $path)
                         .accessibilityIdentifier("Settings")
                 }
             }

--- a/BikeIndex/View/Settings/AppVersionInfo.swift
+++ b/BikeIndex/View/Settings/AppVersionInfo.swift
@@ -1,0 +1,18 @@
+//
+//  AppVersionInfo.swift
+//  BikeIndex
+//
+//  Created by Jack on 1/18/25.
+//
+
+import SwiftUI
+
+struct AppVersionInfo {
+    var marketingVersion: String? {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    }
+
+    var buildNumber: String? {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String
+    }
+}

--- a/BikeIndex/View/Settings/SettingsAttributionCaption.swift
+++ b/BikeIndex/View/Settings/SettingsAttributionCaption.swift
@@ -1,0 +1,33 @@
+//
+//  SettingsAttributionCaption.swift
+//  BikeIndex
+//
+//  Created by Jack on 1/18/25.
+//
+
+import SwiftUI
+
+/// Display attirbution captions about the app, usually in a SettingsPage footer
+struct SettingsAttributionCaption: View {
+    let appVersion = AppVersionInfo()
+
+    var body: some View {
+        HStack {
+            Spacer()
+            VStack {
+                Text("Made with 💝 in Pittsburgh, PA")
+                if let marketingVersion = appVersion.marketingVersion,
+                   let buildNumber = appVersion.buildNumber {
+                    Text("Version \(marketingVersion) (\(buildNumber))")
+                        .font(.caption)
+                }
+            }
+            Spacer()
+        }
+        .padding(.top)
+    }
+}
+
+#Preview {
+    SettingsAttributionCaption()
+}

--- a/BikeIndex/View/Settings/SettingsPage.swift
+++ b/BikeIndex/View/Settings/SettingsPage.swift
@@ -1,5 +1,5 @@
 //
-//  SettingsView.swift
+//  SettingsPage.swift
 //  BikeIndex
 //
 //  Created by Jack on 11/18/23.
@@ -11,7 +11,7 @@ import OSLog
 import PreviewGallery
 #endif
 
-struct SettingsView: View {
+struct SettingsPage: View {
     @Environment(Client.self) var client
 
     @State var iconsModel = AlternateIconsModel()
@@ -200,7 +200,7 @@ struct SettingsView: View {
 #Preview {
     @Previewable @State var path = NavigationPath()
     NavigationStack(path: $path) {
-        SettingsView(
+        SettingsPage(
             iconsModel: AlternateIconsModel(),
             path: $path
         )

--- a/BikeIndex/View/Settings/SettingsPage.swift
+++ b/BikeIndex/View/Settings/SettingsPage.swift
@@ -106,12 +106,7 @@ struct SettingsPage: View {
                 Text("About")
             }
             footer: {
-                HStack {
-                    Spacer()
-                    Text("Made with 💝 in Pittsburgh, PA")
-                    Spacer()
-                }
-                .padding(.top)
+                SettingsAttributionCaption()
             }
         }
         .navigationTitle("Settings")

--- a/BikeIndex/View/TextLink.swift
+++ b/BikeIndex/View/TextLink.swift
@@ -22,9 +22,9 @@ enum MailToLink: Identifiable {
             let subject = URLQueryItem(name: "subject", value: "iOS App Help Request")
             var queryItems: [URLQueryItem] = [subject]
 
-            if let info = Bundle.main.infoDictionary,
-               let marketingVersion = info["CFBundleShortVersionString"],
-               let buildNumber = info["CFBundleVersion"]
+            let info = AppVersionInfo()
+            if let marketingVersion = info.marketingVersion,
+               let buildNumber = info.buildNumber
             {
                 let body = URLQueryItem(name: "body", value: "\r\n\r\nVersion: \(marketingVersion) (\(buildNumber))")
                 queryItems.append(body)


### PR DESCRIPTION
# Description

- Display full app version in Settings (marketing version + build number)

### Screenshots

| Before | After |
| -- | -- |
| ![Simulator Screenshot - iPhone 16 - 2025-01-18 at 15 20 49](https://github.com/user-attachments/assets/124bc9f9-565f-4620-befb-e1c969ae27db) | ![Simulator Screenshot - iPhone 16 - 2025-01-18 at 15 20 14](https://github.com/user-attachments/assets/b3d08b11-3e57-404c-8168-755f9e297a9e) |
