### PR TITLE
Fix: side-step build failure on Preview macro by removing do-catch

### DIFF
--- a/BikeIndex/View/MainContent/ContentBikeButton.swift
+++ b/BikeIndex/View/MainContent/ContentBikeButton.swift
@@ -135,30 +135,25 @@ struct ContentBikeButtonView: View {
     let samples = [sampleBike1, sampleBike2, sampleBike3, sampleBike4]
     let sampleIdentifiers = samples.map { $0.identifier }
 
-    do {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let mockContainer = try ModelContainer(
-            for: Bike.self,
-            configurations: config
-        )
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let mockContainer = try! ModelContainer(
+        for: Bike.self,
+        configurations: config
+    )
 
-        for model in samples {
-            try mockContainer.mainContext.insert(model)
-        }
-        try mockContainer.mainContext.save()
+    samples.forEach { model in
+        mockContainer.mainContext.insert(model)
+    }
+    try! mockContainer.mainContext.save()
 
-        return ScrollView {
-            ProportionalLazyVGrid {
-                ForEach(sampleIdentifiers, id: \.self) {
-                    ContentBikeButtonView(path: $navigationPath,
-                                          bikeIdentifier: $0)
-                }
+    return ScrollView {
+        ProportionalLazyVGrid {
+            ForEach(sampleIdentifiers, id: \.self) {
+                ContentBikeButtonView(path: $navigationPath,
+                                      bikeIdentifier: $0)
             }
         }
-        .modelContainer(mockContainer)
-
-    } catch (let error) {
-        return Text("Preview Error: \(error)")
     }
+    .modelContainer(mockContainer)
 }
 

--- a/BikeIndexUITests/AuthenticatedUITestCase.swift
+++ b/BikeIndexUITests/AuthenticatedUITestCase.swift
@@ -24,6 +24,7 @@ extension XCTestCase {
 
         let timeout: TimeInterval = 120
 
+        // Configure these values in SharedTests/Test-credentials.xcconfig (see adjacent template file)
         let uiTestBundle = try XCTUnwrap(Bundle(identifier: "org.bikeindex.BikeIndexUITests"))
         let infoDictionary = try XCTUnwrap(uiTestBundle.infoDictionary)
         let testUsername = try XCTUnwrap(infoDictionary["TEST_USERNAME"] as? String)

--- a/BikeIndexUITests/BikeIndexUITests.swift
+++ b/BikeIndexUITests/BikeIndexUITests.swift
@@ -147,9 +147,11 @@ final class BikeIndexUITests: XCTestCase {
 
         backButton.tap()
 
+        // Conditional because iPad has enough space to display LICENSE.txt without tapping "View all files"
         let viewAllFiles = app.webViews.buttons["View all files"]
-        _ = viewAllFiles.waitForExistence(timeout: timeout)
-        viewAllFiles.tap()
+        if viewAllFiles.waitForExistence(timeout: timeout) {
+            viewAllFiles.tap()
+        }
 
         let licenseTxtLink = link(with: "LICENSE.txt")
         let licenseExists = licenseTxtLink.waitForExistence(timeout: timeout)


### PR DESCRIPTION
# Description 

- Archive builds were failing due to control flow in this `#Preview` macro
- Old implementation succeeds for Debug builds