### PR TITLE
Fix: Bike Registration dismiss action

### DIFF
--- a/BikeIndex/View/Registering/RegisterBikeView.swift
+++ b/BikeIndex/View/Registering/RegisterBikeView.swift
@@ -16,6 +16,7 @@ struct RegisterBikeView: View {
     // @Environment(\.dismiss) private var dismiss // Can't use with NavigableWebView for serial or how-to-recover links
     @Environment(\.modelContext) private var modelContext
     @Environment(Client.self) var client
+    @Environment(\.dismiss) var dismiss
 
     // MARK: Shadow State
 
@@ -323,7 +324,7 @@ struct RegisterBikeView: View {
                     /// Access dismiss directly.
                     /// If ``RegisterBikeView`` captures the Environment object in a var it will conflict with the
                     /// NavigableWebViews and cause an infinite loop. (I think that's the cause).
-                    Environment(\.dismiss).wrappedValue.callAsFunction()
+                    dismiss()
                 }, message: "", title: "Success!")
             }
 


### PR DESCRIPTION
# Description

- Fix navigation error, UI would wrongly remain on registration page.
- Console warning from previous implementation:

> Accessing Environment<DismissAction>'s value outside of being installed on a View. This will always read the default value and will not update.
