### PR TITLE
Fix: pop-to-root during Sign Out to work around warning

### DIFF
--- a/BikeIndex/View/Settings/SettingsPage.swift
+++ b/BikeIndex/View/Settings/SettingsPage.swift
@@ -50,7 +50,7 @@ struct SettingsPage: View {
                         Label("Registration Organization", systemImage: "person.badge.shield.checkmark")
                     }
 
-                    Button(action: client.destroySession) {
+                    Button(action: logout) {
                         Label("Sign out", systemImage: "figure.walk.departure")
                             .tint(Color.highlightPrimary)
                             .foregroundStyle(Color.highlightPrimary)
@@ -169,6 +169,11 @@ struct SettingsPage: View {
                 .navigationTitle("Terms of Service")
             }
         }
+    }
+
+    func logout() {
+        path = NavigationPath()
+        client.destroySession()
     }
 
     /// Excluding signOut and contactUs which don't navigate internally


### PR DESCRIPTION
# Description

Work-around warning encountered on iOS 18 when signing out:
> The `navigationDestination` modifier only works inside a `NavigationStack` or `NavigationSplitView`. There's a misplaced `navigationDestination(for:destination:)` modifier for type `SettingsSelection`. It will be ignored.

Sign-out works by invoking `Client.destroySession()` which 1) resets the authentication state and 2) causes BikeIndexApp's `body { if client.authenticated }` to render.