### PR TITLE
Fix: Add CI validate archive check for release tags

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -38,3 +38,28 @@ jobs:
           name: test_output.zip
           path: "fastlane/test_output/*"
           compression-level: 9 # maximum compression
+
+  build:
+    name: Validate archive
+    runs-on: macos-15
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install tools
+        run: |
+          brew bundle install
+          bundler install
+      - name: Set up xcconfig secrets (see README.md#quick-start)
+        env:
+          BIKE_INDEX_DEVELOPMENT_XCCONFIG: ${{ secrets.BIKE_INDEX_DEVELOPMENT_XCCONFIG }}
+        run: |
+          echo "$BIKE_INDEX_DEVELOPMENT_XCCONFIG" >> BikeIndex-development.xcconfig
+      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
+        env:
+          BIKE_INDEX_TEST_CREDENTIALS: ${{ secrets.BIKE_INDEX_TEST_CREDENTIALS }}
+        run: |
+          echo "$BIKE_INDEX_TEST_CREDENTIALS" >> SharedTests/Test-credentials.xcconfig
+      - name: Build and validate archive
+        id: fastlane-gym-archive
+        run: bundle exec fastlane gym

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,6 +28,6 @@ platform :ios do
               reset_simulator: true,
               result_bundle: true,
               include_simulator_logs: true,
-              number_of_retries: 5)
+              number_of_retries: 3)
   end
 end

--- a/fastlane/Gymfile
+++ b/fastlane/Gymfile
@@ -1,0 +1,11 @@
+# For more information about this configuration visit
+# https://docs.fastlane.tools/actions/gym/#gymfile
+
+# In general, you can use the options available
+# fastlane gym --help
+
+project("BikeIndex.xcodeproj")
+
+scheme("Debug (development)")
+
+output_directory("./fastlane/gym_output")


### PR DESCRIPTION
# Description

- Must be able to build and archive for "Any iOS Device" for App Store submission
- Add a check to make sure this succeeds
- Might be better on the `main` branch (definitely not desired on feature branches)