### PR TITLE
Feat: Replace URL(string:).unsafelyUnwrapped with URL: ExpressibleByStringLiteral

### DIFF
--- a/BikeIndex/Model/Settings/AcknowledgementPackage.swift
+++ b/BikeIndex/Model/Settings/AcknowledgementPackage.swift
@@ -27,39 +27,39 @@ extension AcknowledgementPackage {
             title: "Bike Index",
             license: .gnuAfferoGPLv3,
             copyright: "2023 © Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194",
-            repository: URL(string: "https://github.com/bikeindex/bike_index")!),
+            repository: URL("https://github.com/bikeindex/bike_index")),
         AcknowledgementPackage(
             title: "Bike Index iOS",
             license: .gnuAfferoGPLv3,
             copyright: "2023 © Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194",
-            repository: URL(string: "https://github.com/bikeindex/bike_index_ios")!),
+            repository: URL("https://github.com/bikeindex/bike_index_ios")),
 
         // MARK: MIT
         AcknowledgementPackage(
             title: "KeychainSwift",
             license: .mit,
             copyright: "Copyright © 2015 - 2021 Evgenii Neumerzhitckii",
-            repository: URL(string: "https://github.com/evgenyneu/keychain-swift")!),
+            repository: URL("https://github.com/evgenyneu/keychain-swift")),
         AcknowledgementPackage(
             title: "URLEncodedForm",
             license: .mit,
             copyright: "Copyright © 2023 Scott Moon",
-            repository: URL(string: "https://github.com/forXifLess/URLEncodedForm")!),
+            repository: URL("https://github.com/forXifLess/URLEncodedForm")),
         AcknowledgementPackage(
             title: "WebViewKit",
             license: .mit,
             copyright: "Copyright © 2022 Daniel Saidi",
-            repository: URL(string: "https://github.com/danielsaidi/WebViewKit")!),
+            repository: URL("https://github.com/danielsaidi/WebViewKit")),
         AcknowledgementPackage(
             title: "SnapshotPreviews",
             license: .mit,
             copyright: "Copyright © 2023 Emerge Tools",
-            repository: URL(string: "https://github.com/EmergeTools/SnapshotPreviews")!),
+            repository: URL("https://github.com/EmergeTools/SnapshotPreviews")),
         AcknowledgementPackage(
             title: "SwiftData-SectionedQuery",
             license: .mit,
             copyright: "Copyright © 2023 Thomas Magis-Agosta",
-            repository: URL(string: "https://github.com/beechtom/swiftdata-sectionedquery")!),
+            repository: URL("https://github.com/beechtom/swiftdata-sectionedquery")),
     ]
 
     static var gnuAfferoGPLv3Packages: [AcknowledgementPackage] {

--- a/BikeIndex/Utility/URL+ExpressibleByStringLiteral.swift
+++ b/BikeIndex/Utility/URL+ExpressibleByStringLiteral.swift
@@ -1,0 +1,17 @@
+//
+//  URL+ExpressibleByStringLiteral.swift
+//  BikeIndex
+//
+//  Created by Jack on 3/16/25.
+//
+
+import Foundation
+
+/// Inspired by SwiftLee Weekly - Issue 260
+extension URL: @retroactive ExpressibleByExtendedGraphemeClusterLiteral {}
+extension URL: @retroactive ExpressibleByUnicodeScalarLiteral {}
+extension URL: @retroactive ExpressibleByStringLiteral {
+    public init(stringLiteral value: StaticString) {
+        self.init(string: "\(value)")!
+    }
+}

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -68,7 +68,7 @@ struct MainContentPage: View {
                     RegisterBikeView(mode: .myStolenBike)
                 case .searchBikes:
                     NavigableWebView(
-                        url: .constant(URL(string: "https://bikeindex.org/bikes?stolenness=all")!)
+                        url: .constant(URL("https://bikeindex.org/bikes?stolenness=all"))
                     )
                     .environment(client)
                 }

--- a/BikeIndex/View/Settings/AcknowledgementPackageDetailView.swift
+++ b/BikeIndex/View/Settings/AcknowledgementPackageDetailView.swift
@@ -33,7 +33,7 @@ struct AcknowledgementPackageDetailView: View {
         title: "BikeIndex iOS",
         license: .gnuAfferoGPLv3,
         copyright: "2023 © Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194",
-        repository: URL(string: "https://github.com/bikeindex/bike_index_ios")!)
+        repository: URL("https://github.com/bikeindex/bike_index_ios"))
     let showUrl: Binding<Bool> = Binding {
         false
     } set: { _ in

--- a/BikeIndex/View/Web/NavigableWebView.swift
+++ b/BikeIndex/View/Web/NavigableWebView.swift
@@ -83,7 +83,7 @@ struct NavigableWebView: View {
 
 #Preview {
     NavigableWebView(
-        url: .constant(URL(string: "https://bikeindex.org")!),
+        url: .constant(URL("https://bikeindex.org")),
         navigator: HistoryNavigator()
     )
     .environment(try! Client())

--- a/UnitTests/BikeIndexOrgApiV3Tests.swift
+++ b/UnitTests/BikeIndexOrgApiV3Tests.swift
@@ -14,7 +14,7 @@ final class BikeIndexOrgApiV3Tests: XCTestCase {
         let token = UUID().uuidString
         let config = EndpointConfiguration(
             accessToken: token,
-            host: URL(string: "https://bikeindex.org/")!)
+            host: URL("https://bikeindex.org/"))
 
         let identifier = "0987654321"
         let path = Bikes.bikes(identifier: identifier)


### PR DESCRIPTION
# Description

- Inspired by SwiftLee Weekly - Issue 260
- Replace `URL(string:).unsafelyUnwrapped` with `URL(stringLiteral:)` which does not require unwrapping