### PR TITLE
Fix: Update RegisterBikeView binding on Bike.serial to update

### DIFF
--- a/BikeIndex/View/Registering/RegisterBikeView.swift
+++ b/BikeIndex/View/Registering/RegisterBikeView.swift
@@ -95,14 +95,16 @@ struct RegisterBikeView: View {
 
             // MARK: Serial number
             Section {
-                let safeSerial = Binding {
-                    bike.serial ?? ""
-                } set: { newValue in
-                    bike.serial = newValue
-                    if let serial = bike.serial, !serial.isEmpty {
-                        missingSerial = false
-                    }
-                }
+                let safeSerial = Binding(
+                    get: {
+                        $bike.serial.wrappedValue ?? ""
+                    },
+                    set: { newValue in
+                        bike.serial = newValue
+                        if let serial = bike.serial, !serial.isEmpty {
+                            missingSerial = false
+                        }
+                    })
 
                 TextField(text: safeSerial) {
                     if missingSerial {


### PR DESCRIPTION
# Description

- Binding.get {} needed to use $bike.serial binding _and then_ retrieve the wrappedValue instead of accessing the string value once directly
- See Binding+Optional.swift for reference (but this instance needs to update the missingSerial field too)