### PR TITLE
Fix: remove dismiss env var from RegisterBikeView to fix nav issues

### DIFF
--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -63,9 +63,9 @@ struct MainContentPage: View {
                     SettingsPage(path: $path)
                         .accessibilityIdentifier("Settings")
                 case .registerBike:
-                    RegisterBikeView(mode: .myOwnBike)
+                    RegisterBikeView(path: $path, mode: .myOwnBike)
                 case .lostBike:
-                    RegisterBikeView(mode: .myStolenBike)
+                    RegisterBikeView(path: $path, mode: .myStolenBike)
                 case .searchBikes:
                     NavigableWebView(
                         url: .constant(URL("https://bikeindex.org/bikes?stolenness=all"))

--- a/BikeIndex/View/Registering/RegisterBikeView.swift
+++ b/BikeIndex/View/Registering/RegisterBikeView.swift
@@ -11,11 +11,11 @@ import SwiftUI
 import WebViewKit
 
 /// NOTE: Adopt @Focus State https://developer.apple.com/documentation/swiftui/focusstate
-/// NOTE: Possibly add organization selection
 struct RegisterBikeView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(Client.self) var client
-    @Environment(\.dismiss) var dismiss
+
+    @Binding var path: NavigationPath
 
     // MARK: Shadow State
 
@@ -302,7 +302,7 @@ struct RegisterBikeView: View {
                 ownerEmail = user.email
             } else {
                 Logger.views.info(
-                    "Failed to find authenticated users with email, skiping association of ownerEmail. Authenticated users has count \(authenticatedUsers.count)"
+                    "Failed to find authenticated users with email, skipping association of ownerEmail. Authenticated users has count \(authenticatedUsers.count)"
                 )
             }
         }
@@ -315,7 +315,7 @@ struct RegisterBikeView: View {
         }
     }
 
-    /// Marshall the Bike model to a Postable intermediary, write that intermediary to the API client and discard Bike model
+    /// Marshall the Bike model to a ``Postable`` intermediary, write that intermediary to the API client and discard Bike model
     /// Receive the result and persist the server's model
     /// Update the UI
     private func registerBike() async {
@@ -354,10 +354,8 @@ struct RegisterBikeView: View {
                 self.validationModel = AddBikeOutput(
                     show: true,
                     actions: {
-                        /// Access dismiss directly.
-                        /// If ``RegisterBikeView`` captures the Environment object in a var it will conflict with the
-                        /// NavigableWebViews and cause an infinite loop. (I think that's the cause).
-                        dismiss()
+                        // After success, pop RegisterBikeView
+                        path.removeLast()
                     }, message: "", title: "Success!")
             }
 
@@ -396,13 +394,15 @@ struct RegisterBikeView: View {
 
     let auth = AuthenticatedUser(identifier: "1", bikes: [bike])
 
-    let previewContent = RegisterBikeView(mode: .myOwnBike, bike: bike)
-        .environment(client)
-        .modelContainer(container)
-        .onAppear {
-            auth.user = user
-            container.mainContext.insert(auth)
-        }
+    let previewContent = RegisterBikeView(
+        path: .constant(NavigationPath()), mode: .myOwnBike, bike: bike
+    )
+    .environment(client)
+    .modelContainer(container)
+    .onAppear {
+        auth.user = user
+        container.mainContext.insert(auth)
+    }
     if ProcessInfo().isRunningPreviews {
         NavigationStack {
             previewContent
@@ -429,13 +429,15 @@ struct RegisterBikeView: View {
 
     let auth = AuthenticatedUser(identifier: "1", bikes: [bike])
 
-    let previewContent = RegisterBikeView(mode: .myStolenBike, bike: bike)
-        .environment(client)
-        .modelContainer(container)
-        .onAppear {
-            auth.user = user
-            container.mainContext.insert(auth)
-        }
+    let previewContent = RegisterBikeView(
+        path: .constant(NavigationPath()), mode: .myStolenBike, bike: bike
+    )
+    .environment(client)
+    .modelContainer(container)
+    .onAppear {
+        auth.user = user
+        container.mainContext.insert(auth)
+    }
     if ProcessInfo().isRunningPreviews {
         NavigationStack {
             previewContent

--- a/BikeIndex/View/TextLink.swift
+++ b/BikeIndex/View/TextLink.swift
@@ -126,7 +126,7 @@ enum BikeIndexLink: Identifiable {
 }
 
 /// Display constant and clickable Markdown links for Production
-/// Display dyanmic and non-clickable Markdown links for Development
+/// Display dynamic and non-clickable Markdown links for Development
 ///
 /// Why does this exist??
 /// `Text` does **not** support `URL`s. You must provide a constant _string_.
@@ -140,7 +140,7 @@ struct TextLink: View {
 }
 
 #Preview {
-    let localhost = URL(string: "http://localhost").unsafelyUnwrapped
+    let localhost = URL(stringLiteral: "http://localhost")
     return VStack {
         ForEach([BikeIndexLink.oauthApplications, .serials, .stolenBikeFAQ]) { item in
             TextLink(base: localhost, link: item)

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -164,9 +164,9 @@ final class BikeIndexUITests: XCTestCase {
         // PUSH: github.com LICENSE.txt
 
         // Back should be available after navigating forward but it will _not be available_ because of GitHub
-//        XCTAssertFalse(backButton.isEnabled)
+        // XCTAssertFalse(backButton.isEnabled)
         // Technically should be false but because GitHub has JS navigation some behaviors are imperfect.
-//        XCTAssertTrue(forwardButton.isEnabled)
+        // XCTAssertTrue(forwardButton.isEnabled)
 
         backButton.tap()
         // POP: github.com LICENSE.txt
@@ -187,7 +187,30 @@ final class BikeIndexUITests: XCTestCase {
             NSPredicate(format: "label BEGINSWITH %@", "Every bike has a unique"))
         if goToOurSerialPage.element.waitForExistence(timeout: timeout) {
             goToOurSerialPage.element.tap()
+        } else {
+            XCTFail("Expected markdown link at 'go to our serial page'")
         }
+
+        back()
+    }
+
+    func test_register_bike_stolen_guide_link() throws {
+        app.launch()
+        try signIn(app: app)
+
+        let registerBikeButton = app.buttons["Register a stolen bike"]
+        _ = registerBikeButton.waitForExistence(timeout: timeout)
+        registerBikeButton.tap()
+
+        let goToHowToGetYourBikeBackPage = app.staticTexts.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "⚠️ How to get your stolen bike back"))
+        if goToHowToGetYourBikeBackPage.element.waitForExistence(timeout: timeout) {
+            goToHowToGetYourBikeBackPage.element.tap()
+        } else {
+            XCTFail("Expected markdown link at 'How to get your stolen bike back'")
+        }
+
+        back()
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
# Description

- Replace @Environment(\.dismiss) with NavigationPath.pop() which is stable on iOS 18.2
- 'Serial info' link and "How to get your stolen bike back" links opened an infinite recursion on Environment Dismiss changed on v1.2 beta build
- Fix typos and add documentation