### PR TITLE
Feat: Add Help link

### DIFF
--- a/BikeIndex/Model/Navigation/MainContent.swift
+++ b/BikeIndex/Model/Navigation/MainContent.swift
@@ -10,13 +10,14 @@ import Foundation
 enum MainContent: Identifiable {
     var id: Self { self }
 
-    //
+    /// General
     case settings
+    case help
 
-    //
+    /// Registration
     case registerBike
     case lostBike
 
-    //
+    /// Search
     case searchBikes
 }

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -62,15 +62,19 @@ struct MainContentPage: View {
                 case .settings:
                     SettingsPage(path: $path)
                         .accessibilityIdentifier("Settings")
+                case .help:
+                    NavigableWebView(
+                        constantLink: .help,
+                        host: client.configuration.host
+                    )
+                    .environment(client)
                 case .registerBike:
                     RegisterBikeView(path: $path, mode: .myOwnBike)
                 case .lostBike:
                     RegisterBikeView(path: $path, mode: .myStolenBike)
                 case .searchBikes:
-                    NavigableWebView(
-                        url: .constant(URL("https://bikeindex.org/bikes?stolenness=all"))
-                    )
-                    .environment(client)
+                    SearchBikesView()
+                        .environment(client)
                 }
             }
             .navigationDestination(for: PersistentIdentifier.self) { identifier in

--- a/BikeIndex/View/MainContent/MainToolbar.swift
+++ b/BikeIndex/View/MainContent/MainToolbar.swift
@@ -7,21 +7,34 @@
 
 import SwiftUI
 
+/// Toolbar for authenticated users on the regular ``MainContentPage``.
 struct MainToolbar: ToolbarContent {
-    @Environment(Client.self) var client
-
-    @State var searchTerms: [SearchTerm] = []
-    @State var serialNumberSearch: String = ""
-    @State var searchMode: GlobalSearchMode = .withinHundredMiles
     @Binding var path: NavigationPath
 
     var body: some ToolbarContent {
-        ToolbarItem(placement: .topBarLeading) {
+        ToolbarItemGroup(placement: .topBarLeading) {
+            // Settings
             Button {
                 path.append(MainContent.settings)
             } label: {
                 Label("Settings", systemImage: "gearshape")
             }
+
+            // Help
+            Button {
+                path.append(MainContent.help)
+            } label: {
+                Label("Help", systemImage: "book.closed")
+            }
         }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        Text("MainToolbar")
+            .toolbar {
+                MainToolbar(path: .constant(NavigationPath()))
+            }
     }
 }

--- a/BikeIndex/View/Onboarding/AuthView.swift
+++ b/BikeIndex/View/Onboarding/AuthView.swift
@@ -54,11 +54,11 @@ struct AuthView: View {
                     }
 
                     ToolbarItemGroup(placement: .topBarLeading) {
-#if DEBUG
+                        #if DEBUG
                         NavigationLink(value: ViewModel.Nav.debugSettings) {
                             Label("Settings", systemImage: "gearshape")
                         }
-#endif
+                        #endif
                         NavigationLink(value: ViewModel.Nav.help) {
                             Label("Help", systemImage: "book.closed")
                         }

--- a/BikeIndex/View/Onboarding/AuthView.swift
+++ b/BikeIndex/View/Onboarding/AuthView.swift
@@ -53,13 +53,16 @@ struct AuthView: View {
                         .buttonStyle(.borderedProminent)
                     }
 
-                    #if DEBUG
-                    ToolbarItem(placement: .topBarLeading) {
+                    ToolbarItemGroup(placement: .topBarLeading) {
+#if DEBUG
                         NavigationLink(value: ViewModel.Nav.debugSettings) {
                             Label("Settings", systemImage: "gearshape")
                         }
+#endif
+                        NavigationLink(value: ViewModel.Nav.help) {
+                            Label("Help", systemImage: "book.closed")
+                        }
                     }
-                    #endif
                 }
                 .navigationTitle("Welcome to Bike Index")
                 .navigationBarTitleDisplayMode(.inline)
@@ -67,7 +70,12 @@ struct AuthView: View {
                     switch navSelection {
                     case .debugSettings:
                         SettingsPage(path: $viewModel.topLevelPath)
+                            .environment(client)
                             .accessibilityIdentifier("Settings")
+                    case .help:
+                        NavigableWebView(constantLink: .help, host: client.configuration.host)
+                            .environment(client)
+                            .navigationTitle("Help")
                     }
                 }
         }
@@ -81,7 +89,7 @@ struct AuthView: View {
                 .navigationTitle("Sign in")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
-                    ToolbarItemGroup(placement: .topBarLeading) {
+                    ToolbarItem(placement: .topBarLeading) {
                         Button("Close") {
                             viewModel.displaySignIn = false
                         }

--- a/BikeIndex/View/SearchBikesView.swift
+++ b/BikeIndex/View/SearchBikesView.swift
@@ -8,123 +8,20 @@
 import SwiftData
 import SwiftUI
 
-protocol SearchValue {
-    var value: String { get }
-}
-
-protocol Displayable {
-    var display: any View { get }
-}
-
-/// Represents auto-completable 'chips' that are distinct UI elements
-enum SearchTerm: SearchValue, Displayable {
-    case color(FrameColor)
-    case motorized  // aka electric
-    case manufacturer(AutocompleteManufacturer)  // TODO: Replace with canonical Manufacturer model
-    case type(BicycleType)
-
-    var value: String {
-        switch self {
-        case .color(let color):
-            return color.displayValue
-        case .motorized:
-            return "Motorized"
-        case .manufacturer(let manufacturer):
-            return manufacturer.text
-        case .type(let type):
-            return type.name
-        }
-    }
-
-    var display: any View {
-        return Text(self.value)
-    }
-}
-
 struct SearchBikesView: View {
-    @Environment(\.modelContext) private var modelContext
     @Environment(Client.self) var client
 
-    @Binding var searchTerms: [SearchTerm]
-    @Binding var serialNumberSearch: String
-    @Binding var searchMode: GlobalSearchMode
-    @Query var bikeQueryResults: [Bike]
-
     var body: some View {
-        Section {
-            List {
-                ForEach(bikeQueryResults) { bike in
-                    VStack {
-                        Text(bike.bikeDescription ?? "<empty>")
-                        if let location = bike.stolenLocation {
-                            Text(location)
-                        }
-                    }
-                }
-            }
-        } header: {
-            HStack {
-                VStack {
-                    TextField(text: $serialNumberSearch) {
-                        Text("Search bike descriptions")
-                    }
-
-                    TextField(text: $serialNumberSearch) {
-                        Text("_Search for serial number_")
-                    }
-                }
-                .padding(.leading, 8)
-
-                Button(
-                    action: {
-                        //                    client.queryGlobal(
-                        //                        // fill in endpoint and params
-                        //                        context: modelContext
-                        //                    )
-                    },
-                    label: {
-                        Image(systemName: "magnifyingglass")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .padding(18)
-                            .accessibilityLabel("Search")
-                            .frame(maxWidth: 60)
-                            .frame(maxHeight: 60)
-                            .scaledToFill()
-                    }
-                )
-                .foregroundStyle(Color.white)
-                .background(Color.blue)
-                .padding(.trailing, 8)
-            }
-
-            // TODO: Replace this with our own vertical picker
-            VerticalPicker(activeMode: $searchMode)
-        } footer: {
-            Text("No more results")
-        }
-
+        NavigableWebView(
+            url: .constant(URL(stringLiteral: "https://bikeindex.org/bikes?stolenness=all"))
+        )
         .navigationTitle(Text("Search Bikes"))
     }
 }
 
 #Preview {
-    do {
-        let client = try Client()
-
-        return NavigationStack {
-            SearchBikesView(
-                searchTerms: .constant([.color(.red)]),
-                serialNumberSearch: .constant(""),
-                searchMode: .constant(.withinHundredMiles)
-            )
-            .environment(client)
-            .modelContainer(
-                for: Bike.self,
-                inMemory: true,
-                isAutosaveEnabled: false)
-        }
-    } catch let error {
-        return Text("Failed to load preview \(error.localizedDescription)")
+    NavigationStack {
+        SearchBikesView()
+            .environment(try! Client())
     }
 }

--- a/BikeIndex/View/Settings/AcknowledgementPackageDetailView.swift
+++ b/BikeIndex/View/Settings/AcknowledgementPackageDetailView.swift
@@ -14,7 +14,7 @@ struct AcknowledgementPackageDetailView: View {
     var body: some View {
         Text(package.fullLicense())
             .toolbar {
-                ToolbarItemGroup(placement: .topBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button(
                         action: {
                             showRepositoryUrl = true

--- a/BikeIndex/View/TextLink.swift
+++ b/BikeIndex/View/TextLink.swift
@@ -46,6 +46,7 @@ enum BikeIndexLink: Identifiable {
     case stolenBikeFAQ
     case privacyPolicy
     case termsOfService
+    case help
 
     // MARK: Account
     case accountUserSettings
@@ -68,7 +69,7 @@ enum BikeIndexLink: Identifiable {
         case .stolenBikeFAQ:
             markdownSource =
                 "Learn more about [How to get your stolen bike back](\(link(base: base)))"
-        case .privacyPolicy, .termsOfService, .deleteAccount, .accountUserSettings,
+        case .help, .privacyPolicy, .termsOfService, .deleteAccount, .accountUserSettings,
             .accountPassword, .accountSharingPersonalPage, .accountRegistrationOrganization:
             return AttributedString()
         }
@@ -105,6 +106,9 @@ enum BikeIndexLink: Identifiable {
         case .termsOfService:
             // https://bikeindex.org/terms
             return "terms"
+        case .help:
+            // https://bikeindex.org/help
+            return "help"
 
         case .accountUserSettings:
             // https://bikeindex.org/my_account/edit

--- a/BikeIndex/ViewModel/Onboarding/AuthViewModel.swift
+++ b/BikeIndex/ViewModel/Onboarding/AuthViewModel.swift
@@ -28,6 +28,7 @@ extension AuthView {
             var id: Self { self }
 
             case debugSettings
+            case help
         }
     }
 }

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -224,3 +224,30 @@ final class BikeIndexUITests: XCTestCase {
         app.links.matching(NSPredicate(format: "label BEGINSWITH %@", prefix)).element
     }
 }
+
+// MARK: - Help button
+extension BikeIndexUITests {
+    /// Note: UI Tests don't really have a way to enforce that the user is signed-out
+    /// to test through the `BikeIndex/AuthView` flow. This omission is passable for this
+    /// test because MainContentPage has the same button. But it may need an answer later.
+    func testUnauthenticatedHelp() throws {
+        app.launch()
+
+        let unauthenticatedHelpButton = app.buttons["Help"]
+        _ = unauthenticatedHelpButton.waitForExistence(timeout: timeout)
+        unauthenticatedHelpButton.tap()
+
+        back()
+    }
+
+    func testMainContentPageHelp() throws {
+        app.launch()
+        try signIn(app: app)
+
+        let unauthenticatedHelpButton = app.buttons["Help"]
+        _ = unauthenticatedHelpButton.waitForExistence(timeout: timeout)
+        unauthenticatedHelpButton.tap()
+
+        back()
+    }
+}


### PR DESCRIPTION
# Description

- Add 📘 `book.closed` Help item to AuthView and MainContentPage toolbars.
- Replace unused `SearchBikesView` with an actual implementation (to fix `URL(stringLiteral:)` usage inside Previews).
- Remove unused native-search state management from MainToolbar.
- Add `BikeIndexLink.help`.
- Add UI test to ensure Help button is tappable, opens, and then back button works.

## Screenshots

| Before - main content | After - main content |
| -- | -- |
| ![Simulator Screenshot - iPhone 16 - 2025-03-29 at 18 31 57](https://github.com/user-attachments/assets/c39ec5ce-5f2f-44ac-b297-c2b98a9a909d) | ![Simulator Screenshot - iPhone 16 - 2025-03-29 at 18 28 34](https://github.com/user-attachments/assets/2153d3a6-1ce5-461d-a7bb-1948397d367a) |

| Before - auth view | After - auth view |
| -- | -- |
| ![Simulator Screenshot - iPhone 16 - 2025-03-29 at 18 31 45](https://github.com/user-attachments/assets/54c94fab-11c8-44bf-90d0-58b8823722d1) | ![Simulator Screenshot - iPhone 16 - 2025-03-29 at 18 29 54](https://github.com/user-attachments/assets/d7e3b017-1f5b-4438-a9d6-1efde3bd2f33) |
