### PR TITLE
Feat: Add applinks entitlement to complete universal links

### DIFF
--- a/BikeIndex/BikeIndex.entitlements
+++ b/BikeIndex/BikeIndex.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:bikeindex.org</string>
+		<string>applinks:bikeindex.org</string>
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>


### PR DESCRIPTION
# Description

- Finish connecting universal links for QR stickers
    - https://github.com/bikeindex/bike_index_ios/pull/55
    - https://github.com/bikeindex/bike_index/pull/2756
- Guide: https://developer.apple.com/documentation/xcode/supporting-associated-domains