### PR TITLE
Fix: Universal Links from the camera when the app is not-launched

### DIFF
--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -49,6 +49,11 @@ struct BikeIndexApp: App {
                             host: client.hostProvider,
                             scannedURL: url)
                     }
+                    .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
+                        client.deeplinkManager = DeeplinkManager(
+                            host: client.hostProvider,
+                            scannedURL: userActivity.webpageURL)
+                    }
             } else {
                 AuthView()
                     .tint(Color.accentColor)
@@ -57,6 +62,12 @@ struct BikeIndexApp: App {
                             host: client.hostProvider,
                             scannedURL: url)
                     }
+                    .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
+                        client.deeplinkManager = DeeplinkManager(
+                            host: client.hostProvider,
+                            scannedURL: userActivity.webpageURL)
+                    }
+
             }
         }
         .environment(client)


### PR DESCRIPTION
# Description

- v1.3 cold start launches from QR sticker camera scans worked
- v1.3 subsequent launches (warm start) from camera scans failed, this PR fixes that scenario