### PR TITLE
Feat: Add expandible sections to MainContentPage

### DIFF
--- a/BikeIndex/API/API.swift
+++ b/BikeIndex/API/API.swift
@@ -9,7 +9,7 @@ import Foundation
 import OSLog
 import URLEncodedForm
 
-/// URL's appending(components: String...) varidic function cannot accept arrays (splatting) so use reduce instead
+/// URL's appending(components: String...) variadic function cannot accept arrays (splatting) so use reduce instead
 extension URL {
     func appending(components: [String]) -> Self {
         return components.reduce(self) { partialResult, path in

--- a/BikeIndex/View/BikeDetail/BikeDetailView.swift
+++ b/BikeIndex/View/BikeDetail/BikeDetailView.swift
@@ -40,7 +40,6 @@ struct BikeDetailView: View {
     }
 
     var body: some View {
-        let _ = Self._printChanges()
         if let bike {
             NavigableWebView(url: $url)
                 .toolbar(content: {

--- a/BikeIndex/View/MainContent/BikesSection.swift
+++ b/BikeIndex/View/MainContent/BikesSection.swift
@@ -12,15 +12,19 @@ struct BikesSection: View {
     @Binding var path: NavigationPath
     private(set) var section: SectionValue
     @Query private var bikes: [Bike]
+    @AppStorage
+    private var isExpanded: Bool
 
     init(path: Binding<NavigationPath>, section: SectionValue) {
         self._path = path
         self.section = section
         _bikes = Query(filter: section.filterPredicate)
+        /// Track expanded state _for each section_
+        _isExpanded = AppStorage(wrappedValue: true, "BikesSection.isExpanded.\(section.displayName)")
     }
 
     var body: some View {
-        Section {
+        Section(isExpanded: $isExpanded) {
             ForEach(Array(bikes.enumerated()), id: \.element) { (index, bike) in
                 ContentBikeButtonView(
                     path: $path,
@@ -30,11 +34,30 @@ struct BikesSection: View {
             }
             .padding()
         } header: {
-            Text(section.displayName)
-                .padding([.top, .bottom], 4)
-                .frame(maxWidth: .infinity)
-                .font(.headline)
+            Button {
+                withAnimation(Animation.smooth(duration: 1.0, extraBounce: 2.0)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                ZStack {
+                    Text(section.displayName)
+                        .padding([.top, .bottom], 4)
+                        .frame(maxWidth: .infinity)
+                        .font(.headline)
+                    HStack {
+                        Spacer()
+                        Image(systemName: "chevron.down")
+                            .rotationEffect(.degrees(isExpanded ? 0 : -90))
+                            .padding(.trailing)
+                            .foregroundStyle(Color.secondary)
+                    }
+                }
                 .background(.ultraThinMaterial)
+            }
+            .accessibilityIdentifier("Section toggle \(section.displayName)")
+            .accessibilityHint("\(isExpanded ? "Collapse" : "Expand") section for \(section.displayName)")
+            .buttonStyle(.plain)
+            .padding([.top, .bottom], 2)
         }
     }
 }
@@ -72,8 +95,12 @@ extension BikesSection {
     @Previewable @State var navigationPath = NavigationPath()
     @Previewable @State var status: BikeStatus = .withOwner
     NavigationStack {
-        BikesSection(
-            path: $navigationPath,
-            section: .byStatus(status))
+        ScrollView {
+            ProportionalLazyVGrid {
+                BikesSection(
+                    path: $navigationPath,
+                    section: .byStatus(status))
+            }
+        }
     }
 }

--- a/BikeIndex/View/MainContent/BikesSection.swift
+++ b/BikeIndex/View/MainContent/BikesSection.swift
@@ -20,7 +20,8 @@ struct BikesSection: View {
         self.section = section
         _bikes = Query(filter: section.filterPredicate)
         /// Track expanded state _for each section_
-        _isExpanded = AppStorage(wrappedValue: true, "BikesSection.isExpanded.\(section.displayName)")
+        _isExpanded = AppStorage(
+            wrappedValue: true, "BikesSection.isExpanded.\(section.displayName)")
     }
 
     var body: some View {
@@ -31,6 +32,7 @@ struct BikesSection: View {
                     bikeIdentifier: bike.identifier
                 )
                 .accessibilityIdentifier("Bike \(index + 1)")
+                .accessibilityValue(bike.bikeDescription ?? bike.manufacturerName)
             }
             .padding()
         } header: {
@@ -54,8 +56,11 @@ struct BikesSection: View {
                 }
                 .background(.ultraThinMaterial)
             }
+            .accessibilityValue("\(isExpanded ? "Expanded" : "Collapsed")")
             .accessibilityIdentifier("Section toggle \(section.displayName)")
-            .accessibilityHint("\(isExpanded ? "Collapse" : "Expand") section for \(section.displayName)")
+            .accessibilityHint(
+                "\(isExpanded ? "Collapse" : "Expand") section for \(section.displayName)"
+            )
             .buttonStyle(.plain)
             .padding([.top, .bottom], 2)
         }

--- a/BikeIndex/View/MainContent/MainToolbar.swift
+++ b/BikeIndex/View/MainContent/MainToolbar.swift
@@ -23,41 +23,48 @@ extension MainContentPage {
                 } label: {
                     Label("Settings", systemImage: "gearshape")
                 }
+                .accessibilityHint("Open application settings")
+
                 // Help
                 Button {
                     path.append(MainContent.help)
                 } label: {
                     Label("Help", systemImage: "book.closed")
                 }
+                .accessibilityHint("Open frequently asked questions and help pages")
             }
 
-            if loading {
-                ToolbarItem(placement: .topBarTrailing) {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                if loading {
                     ProgressView()
                         .tint(Color.primary)
+                        .accessibilityLabel("Loading indicator")
                 }
-            }
-            ToolbarItem(placement: .topBarTrailing) {
+
+                // TODO: Add `Menu(content: label: primaryAction:)` to change sort order (and show sort in icon)
                 Menu {
                     Text("Group by:")
                         .accessibilityLabel("Select one option")
                     ForEach(ViewModel.GroupMode.allCases) { option in
+                        let selected = groupMode == option
                         Button {
                             groupMode = option
                         } label: {
-                            if groupMode == option {
+                            if selected {
                                 Label(option.displayName, systemImage: "checkmark")
-                                    .accessibilityHint(Text("Currently selected"))
                             } else {
                                 Text(option.displayName)
-                                    .accessibilityHint(Text("Not selected"))
                             }
                         }
+                        .accessibilityIdentifier(option.rawValue)
+                        .accessibilityHint(Text(selected ? "Currently selected" : "Not selected"))
                     }
                 } label: {
                     Image(systemName: "slider.horizontal.3")
-                        .accessibilityLabel("Change how bikes are grouped.")
+                        .accessibilityLabel("slider-group")
                 }
+                .accessibilityLabel("Change how bikes are grouped.")
+                .accessibilityIdentifier("main_content_page_group_control")
             }
         }
     }

--- a/UITests/MainContentUITestCase.swift
+++ b/UITests/MainContentUITestCase.swift
@@ -1,0 +1,88 @@
+//
+//  RegisterBikeUITestCase.swift
+//  BikeIndex
+//
+//  Created by Jack on 5/1/25.
+//
+
+import XCTest
+
+@MainActor
+final class MainContentUITestCase: XCTestCase {
+    enum GroupMode: String, CaseIterable, Identifiable, Equatable {
+        case byStatus
+        case byManufacturer
+
+        var id: String { rawValue }
+    }
+
+    let timeout: TimeInterval = 60
+    let app = XCUIApplication()
+    lazy var backButton = app.navigationBars.buttons.element(boundBy: 0)
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
+    }
+
+    func test_main_content_section() throws {
+        app.launch()
+        try signIn(app: app)
+
+        let groupingMenuButton = app.navigationBars.buttons["Change how bikes are grouped."]
+        _ = groupingMenuButton.waitForExistence(timeout: timeout)
+        // https://stackoverflow.com/a/33534187/178805
+        if !groupingMenuButton.isHittable {
+            let coordinate: XCUICoordinate = groupingMenuButton.coordinate(withNormalizedOffset: CGVector(dx:0.0, dy:0.0))
+            coordinate.tap()
+        } else {
+            groupingMenuButton.tap()
+        }
+
+        let groupByStatusButton = app.buttons[GroupMode.byStatus.rawValue]
+        _ = groupByStatusButton.waitForExistence(timeout: timeout)
+        groupByStatusButton.tap()
+
+        let bike1_before_status_collapse_exists = app.buttons["Bike 1"]
+            .waitForExistence(timeout: timeout)
+        XCTAssertTrue(bike1_before_status_collapse_exists)
+
+        //
+        let sectionHeaderStatusWithOwner = app.buttons["Section toggle With Owner"]
+        _ = sectionHeaderStatusWithOwner.waitForExistence(timeout: timeout)
+        sectionHeaderStatusWithOwner.tap()
+
+        //
+        let bike1_after_status_expand_does_not_exist = app.buttons["Bike 1"]
+            .waitForNonExistence(timeout: timeout)
+        XCTAssertTrue(bike1_after_status_expand_does_not_exist)
+        sectionHeaderStatusWithOwner.tap()
+
+        // Change grouping
+        // https://stackoverflow.com/a/33534187/178805
+        if !groupingMenuButton.isHittable {
+            let coordinate: XCUICoordinate = groupingMenuButton.coordinate(withNormalizedOffset: CGVector(dx:0.0, dy:0.0))
+            coordinate.tap()
+        } else {
+            groupingMenuButton.tap()
+        }
+        let groupByManufacturerButton = app.buttons[GroupMode.byManufacturer.rawValue]
+        _ = groupByManufacturerButton.waitForExistence(timeout: timeout)
+        groupByManufacturerButton.tap()
+
+        let bike1_before_manufacturer_collapse_exists = app.buttons["Bike 1"]
+            .waitForExistence(timeout: timeout)
+        XCTAssertTrue(bike1_before_manufacturer_collapse_exists)
+
+        //
+        let sectionHeaderJamis = app.buttons["Section toggle Jamis"]
+        _ = sectionHeaderJamis.waitForExistence(timeout: timeout)
+        sectionHeaderJamis.tap()
+
+        let bike1_after_manufacturer_expand_does_not_exist = app.buttons["Bike 1"]
+            .waitForNonExistence(timeout: timeout)
+        XCTAssertTrue(bike1_after_manufacturer_expand_does_not_exist)
+
+
+    }
+}

--- a/UITests/MainContentUITestCase.swift
+++ b/UITests/MainContentUITestCase.swift
@@ -17,6 +17,7 @@ final class MainContentUITestCase: XCTestCase {
     }
 
     let timeout: TimeInterval = 60
+    let nonExistenceTimeout: TimeInterval = 1
     let app = XCUIApplication()
     lazy var backButton = app.navigationBars.buttons.element(boundBy: 0)
 
@@ -33,7 +34,8 @@ final class MainContentUITestCase: XCTestCase {
         _ = groupingMenuButton.waitForExistence(timeout: timeout)
         // https://stackoverflow.com/a/33534187/178805
         if !groupingMenuButton.isHittable {
-            let coordinate: XCUICoordinate = groupingMenuButton.coordinate(withNormalizedOffset: CGVector(dx:0.0, dy:0.0))
+            let coordinate: XCUICoordinate = groupingMenuButton.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.0, dy: 0.0))
             coordinate.tap()
         } else {
             groupingMenuButton.tap()
@@ -43,25 +45,31 @@ final class MainContentUITestCase: XCTestCase {
         _ = groupByStatusButton.waitForExistence(timeout: timeout)
         groupByStatusButton.tap()
 
+        let sectionHeaderStatusWithOwner = app.buttons["Section toggle With Owner"]
+        _ = sectionHeaderStatusWithOwner.waitForExistence(timeout: timeout)
+        XCTAssertEqual(sectionHeaderStatusWithOwner.value as? String, "Expanded")
+
         let bike1_before_status_collapse_exists = app.buttons["Bike 1"]
             .waitForExistence(timeout: timeout)
         XCTAssertTrue(bike1_before_status_collapse_exists)
 
         //
-        let sectionHeaderStatusWithOwner = app.buttons["Section toggle With Owner"]
-        _ = sectionHeaderStatusWithOwner.waitForExistence(timeout: timeout)
         sectionHeaderStatusWithOwner.tap()
+        XCTAssertEqual(sectionHeaderStatusWithOwner.value as? String, "Collapsed")
 
         //
         let bike1_after_status_expand_does_not_exist = app.buttons["Bike 1"]
-            .waitForNonExistence(timeout: timeout)
+            .waitForNonExistence(timeout: nonExistenceTimeout)
         XCTAssertTrue(bike1_after_status_expand_does_not_exist)
+
+        // Expand status group again
         sectionHeaderStatusWithOwner.tap()
 
         // Change grouping
         // https://stackoverflow.com/a/33534187/178805
         if !groupingMenuButton.isHittable {
-            let coordinate: XCUICoordinate = groupingMenuButton.coordinate(withNormalizedOffset: CGVector(dx:0.0, dy:0.0))
+            let coordinate: XCUICoordinate = groupingMenuButton.coordinate(
+                withNormalizedOffset: CGVector(dx: 0.0, dy: 0.0))
             coordinate.tap()
         } else {
             groupingMenuButton.tap()
@@ -70,19 +78,24 @@ final class MainContentUITestCase: XCTestCase {
         _ = groupByManufacturerButton.waitForExistence(timeout: timeout)
         groupByManufacturerButton.tap()
 
+        let sectionHeaderJamis = app.buttons["Section toggle Jamis"]
+        _ = sectionHeaderJamis.waitForExistence(timeout: timeout)
+        XCTAssertEqual(sectionHeaderJamis.value as? String, "Expanded")
+
         let bike1_before_manufacturer_collapse_exists = app.buttons["Bike 1"]
             .waitForExistence(timeout: timeout)
         XCTAssertTrue(bike1_before_manufacturer_collapse_exists)
 
         //
-        let sectionHeaderJamis = app.buttons["Section toggle Jamis"]
-        _ = sectionHeaderJamis.waitForExistence(timeout: timeout)
         sectionHeaderJamis.tap()
+        XCTAssertEqual(sectionHeaderJamis.value as? String, "Collapsed")
 
         let bike1_after_manufacturer_expand_does_not_exist = app.buttons["Bike 1"]
-            .waitForNonExistence(timeout: timeout)
+            .waitForNonExistence(timeout: nonExistenceTimeout)
         XCTAssertTrue(bike1_after_manufacturer_expand_does_not_exist)
 
+        // Expand manufacturer group again
+        sectionHeaderJamis.tap()
 
     }
 }


### PR DESCRIPTION
# Description

- Special thanks to @calebhearth for this feature request
- Add animations to expandable section indicators (not yet sure how to animate the section contents)
- Begin adding accessibility information to BikesSection custom disclosure control
- Add basic UI test for group control
- Fix some typos

### Screenshots

| Bikes by manufacturer | Bikes by status |
| -- | -- |
| <img width="454" alt="Screenshot 2025-05-03 at 14 50 21" src="https://github.com/user-attachments/assets/dccfd00d-d7bc-4116-ae56-911c53ab2a00" /> | <img width="443" alt="Screenshot 2025-05-03 at 14 49 47" src="https://github.com/user-attachments/assets/b283a80f-6449-47b7-9c4d-f66cc239f783" /> |

| Demo of UI Test in action |
| -- |
| <video src="https://github.com/user-attachments/assets/aefc783f-3807-43f0-a67a-33ae680272ea"> | 