### PR TITLE
Feat: Add image caching

### DIFF
--- a/BikeIndex.xcodeproj/project.pbxproj
+++ b/BikeIndex.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0428F4812D75156300BDD2A5 /* SectionedQuery in Frameworks */ = {isa = PBXBuildFile; productRef = 0428F4802D75156300BDD2A5 /* SectionedQuery */; };
+		044441302DC6A1DC004B19AE /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = 0444412F2DC6A1DC004B19AE /* CachedAsyncImage */; };
 		04ABEBB92D1F35B400E30577 /* PreviewGallery in Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBB82D1F35B400E30577 /* PreviewGallery */; };
 		04ABEBBB2D1F35B400E30577 /* SnapshotPreferences in Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBBA2D1F35B400E30577 /* SnapshotPreferences */; };
 		04ABEBBD2D1F35B400E30577 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = 04ABEBBC2D1F35B400E30577 /* SnapshottingTests */; };
@@ -109,6 +110,7 @@
 				04ABEBBB2D1F35B400E30577 /* SnapshotPreferences in Frameworks */,
 				0428F4812D75156300BDD2A5 /* SectionedQuery in Frameworks */,
 				04F4B95E2B0990CE009442B5 /* KeychainSwift in Frameworks */,
+				044441302DC6A1DC004B19AE /* CachedAsyncImage in Frameworks */,
 				04EA11222B2504340024CDDD /* URLEncodedForm in Frameworks */,
 				04E1343E2B4B718200CE88DD /* WebViewKit in Frameworks */,
 			);
@@ -196,6 +198,7 @@
 				04ABEBB82D1F35B400E30577 /* PreviewGallery */,
 				04ABEBBA2D1F35B400E30577 /* SnapshotPreferences */,
 				0428F4802D75156300BDD2A5 /* SectionedQuery */,
+				0444412F2DC6A1DC004B19AE /* CachedAsyncImage */,
 			);
 			productName = BikeIndex;
 			productReference = 04F4B8F72B098ADB009442B5 /* BikeIndex.app */;
@@ -282,6 +285,7 @@
 				04E1343C2B4B718200CE88DD /* XCRemoteSwiftPackageReference "WebViewKit" */,
 				04ABEBB72D1F35B400E30577 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */,
 				0428F47F2D75156300BDD2A5 /* XCRemoteSwiftPackageReference "swiftdata-sectionedquery" */,
+				0444412E2DC6A1DC004B19AE /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */,
 			);
 			productRefGroup = 04F4B8F82B098ADB009442B5 /* Products */;
 			projectDirPath = "";
@@ -846,6 +850,14 @@
 				minimumVersion = 1.2.0;
 			};
 		};
+		0444412E2DC6A1DC004B19AE /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/lorenzofiamingo/swiftui-cached-async-image.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.1.1;
+			};
+		};
 		04ABEBB72D1F35B400E30577 /* XCRemoteSwiftPackageReference "SnapshotPreviews" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EmergeTools/SnapshotPreviews";
@@ -885,6 +897,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0428F47F2D75156300BDD2A5 /* XCRemoteSwiftPackageReference "swiftdata-sectionedquery" */;
 			productName = SectionedQuery;
+		};
+		0444412F2DC6A1DC004B19AE /* CachedAsyncImage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0444412E2DC6A1DC004B19AE /* XCRemoteSwiftPackageReference "swiftui-cached-async-image" */;
+			productName = CachedAsyncImage;
 		};
 		04ABEBB82D1F35B400E30577 /* PreviewGallery */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/BikeIndex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BikeIndex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "70c1608ccd41988fbed45e9843d1c315e380525ef27a32b9ede486e2b5eca9f0",
+  "originHash" : "e9b1cf963d0fb17cfd73f99e9ab03c749fc91d82e420d787f9cc5643498ce5e9",
   "pins" : [
     {
       "identity" : "accessibilitysnapshot",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "af2451407fe4f3cf06ff52318cd81a1d26df52bd",
         "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swiftui-cached-async-image",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/lorenzofiamingo/swiftui-cached-async-image.git",
+      "state" : {
+        "revision" : "467a3d17479887943ab917a379e62bbaff60ac8a",
+        "version" : "2.1.1"
       }
     },
     {

--- a/BikeIndex/View/MainContent/BikesList.swift
+++ b/BikeIndex/View/MainContent/BikesList.swift
@@ -12,21 +12,29 @@ import SwiftUI
 /// Display multiple sections of bikes together
 struct BikesList: View {
     @Binding var path: NavigationPath
+    @Binding var fetching: Bool
 
     @SectionedQuery(\Bike.statusString)
     var bikes: SectionedResults<String, Bike>
 
     var group: MainContentPage.ViewModel.GroupMode
 
-    init(path: Binding<NavigationPath>, group: MainContentPage.ViewModel.GroupMode) {
+    init(
+        path: Binding<NavigationPath>, fetching: Binding<Bool>,
+        group: MainContentPage.ViewModel.GroupMode
+    ) {
         _path = path
+        _fetching = fetching
         self.group = group
         _bikes = group.sectionQuery
     }
 
     var body: some View {
-        if bikes.isEmpty {
-            ContentUnavailableView("No bikes registered", systemImage: "bicycle.circle")
+        if fetching {
+            ContentUnavailableView("Fetching bikes…", systemImage: "bicycle.circle")
+                .padding()
+        } else if bikes.isEmpty {
+            ContentUnavailableView("No bikes registered", systemImage: "bicycle.circle.fill")
                 .padding()
         } else {
             ProportionalLazyVGrid(pinnedViews: [.sectionHeaders]) {

--- a/BikeIndex/View/MainContent/ContentBikeButton.swift
+++ b/BikeIndex/View/MainContent/ContentBikeButton.swift
@@ -5,6 +5,7 @@
 //  Created by Jack on 1/7/24.
 //
 
+import CachedAsyncImage
 import SwiftData
 import SwiftUI
 
@@ -25,7 +26,7 @@ struct ContentBikeButtonView: View {
             NavigationLink(value: bike.identifier) {
                 VStack {
                     ZStack {
-                        AsyncImage(url: bike.largeImage) { image in
+                        CachedAsyncImage(url: bike.largeImage) { image in
                             image
                                 .resizable()
                                 .scaledToFill()

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -33,6 +33,7 @@ struct MainContentPage: View {
 
                 BikesList(
                     path: $viewModel.path,
+                    fetching: $viewModel.fetching,
                     group: viewModel.groupMode)
             }
             .toolbar {


### PR DESCRIPTION
# Description

- Add https://swiftpackageindex.com/lorenzofiamingo/swiftui-cached-async-image package
- Add CachedAsyncImage for BikesList > BikesSection > ContentBikeButton images
- Separate BikesList empty states for clarity
    1. App is fetching bikes
    2. This user does not have any bike registrations
    3. Bikes are available and displayed
- In the future: BikesList should be renamed to BikesVGrid because it wraps ProportionalLazyVGrid

### Screenshots

| Previous behavior | Updated behavior |
| -- | -- |
| With blue background glitching in and out | Smooth continuous display for the same image! |
| ![Simulator Screen Recording - iPhone 16 - 2025-05-03 at 15 29 21](https://github.com/user-attachments/assets/e63e8100-6a8e-4f89-bdb4-3db4b29c8e66) | ![Simulator Screen Recording - iPhone 16 - 2025-05-03 at 15 30 02](https://github.com/user-attachments/assets/d66ccd38-06f0-44cd-8541-1b3dd7062a31) | 