### PR TITLE
Feat/sort order for bike groups

### DIFF
--- a/BikeIndex/View/MainContent/BikesList.swift
+++ b/BikeIndex/View/MainContent/BikesList.swift
@@ -18,15 +18,20 @@ struct BikesList: View {
     var bikes: SectionedResults<String, Bike>
 
     var group: MainContentPage.ViewModel.GroupMode
+    /// Sort order applies to the sections, not the bikes in each section.
+    var sortOrder: SortOrder
 
     init(
         path: Binding<NavigationPath>, fetching: Binding<Bool>,
-        group: MainContentPage.ViewModel.GroupMode
+        group: MainContentPage.ViewModel.GroupMode,
+        sortOrder: SortOrder
     ) {
         _path = path
         _fetching = fetching
         self.group = group
-        _bikes = group.sectionQuery
+        self.sortOrder = sortOrder
+
+        _bikes = group.sectionQuery(with: sortOrder)
     }
 
     var body: some View {

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -34,13 +34,15 @@ struct MainContentPage: View {
                 BikesList(
                     path: $viewModel.path,
                     fetching: $viewModel.fetching,
-                    group: viewModel.groupMode)
+                    group: viewModel.groupMode,
+                    sortOrder: viewModel.sortOrder)
             }
             .toolbar {
                 MainToolbar(
                     path: $viewModel.path,
                     loading: $viewModel.fetching,
-                    groupMode: $viewModel.groupMode)
+                    groupMode: $viewModel.groupMode,
+                    sortOrder: $viewModel.sortOrder)
             }
             .navigationTitle("Bike Index")
             .navigationDestination(for: MainContent.self) { selection in

--- a/BikeIndex/View/MainContent/MainToolbar.swift
+++ b/BikeIndex/View/MainContent/MainToolbar.swift
@@ -14,6 +14,7 @@ extension MainContentPage {
         @Binding var path: NavigationPath
         @Binding var loading: Bool
         @Binding var groupMode: ViewModel.GroupMode
+        @Binding var sortOrder: SortOrder
 
         var body: some ToolbarContent {
             ToolbarItemGroup(placement: .topBarLeading) {
@@ -41,8 +42,16 @@ extension MainContentPage {
                         .accessibilityLabel("Loading indicator")
                 }
 
-                // TODO: Add `Menu(content: label: primaryAction:)` to change sort order (and show sort in icon)
                 Menu {
+                    // MARK: - Sorty By
+                    Button {
+                        sortOrder = sortOrder.toggle()
+                    } label: {
+                        let systemImage = sortOrder == .forward ? "arrow.down" : "arrow.up"
+                        Label("Sort order:",  systemImage: systemImage)
+                    }
+                    Divider()
+                    // MARK: - Group By
                     Text("Group by:")
                         .accessibilityLabel("Select one option")
                     ForEach(ViewModel.GroupMode.allCases) { option in
@@ -73,13 +82,15 @@ extension MainContentPage {
 #Preview {
     @Previewable @State var path = NavigationPath()
     @Previewable @State var groupMode = MainContentPage.ViewModel.GroupMode.byStatus
+    @Previewable @State var sortOrder: SortOrder = .forward
     NavigationStack {
         Text("Toolbar preview")
             .toolbar {
                 MainContentPage.MainToolbar(
                     path: $path,
                     loading: .constant(true),
-                    groupMode: $groupMode)
+                    groupMode: $groupMode,
+                    sortOrder: $sortOrder)
             }
     }
     .environment(try! Client())

--- a/BikeIndex/View/MainContent/MainToolbar.swift
+++ b/BikeIndex/View/MainContent/MainToolbar.swift
@@ -48,7 +48,7 @@ extension MainContentPage {
                         sortOrder = sortOrder.toggle()
                     } label: {
                         let systemImage = sortOrder == .forward ? "arrow.down" : "arrow.up"
-                        Label("Sort order:",  systemImage: systemImage)
+                        Label("Sort order:", systemImage: systemImage)
                     }
                     Divider()
                     // MARK: - Group By

--- a/BikeIndex/View/MainContent/MainToolbar.swift
+++ b/BikeIndex/View/MainContent/MainToolbar.swift
@@ -50,6 +50,8 @@ extension MainContentPage {
                         let systemImage = sortOrder == .forward ? "arrow.down" : "arrow.up"
                         Label("Sort order:", systemImage: systemImage)
                     }
+                    .accessibilityValue(sortOrder.displayName)
+                    .accessibilityHint("Toggle sort order")
                     Divider()
                     // MARK: - Group By
                     Text("Group by:")
@@ -58,6 +60,7 @@ extension MainContentPage {
                         let selected = groupMode == option
                         Button {
                             groupMode = option
+                            sortOrder = ViewModel.GroupMode.lastKnownSortOrder
                         } label: {
                             if selected {
                                 Label(option.displayName, systemImage: "checkmark")

--- a/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
@@ -47,12 +47,13 @@ extension MainContentPage.ViewModel {
             }
         }
 
-        // MARK: - Persistence
+        // MARK: - Persistence for GroupMode and SortOrder
 
-        static private let persistenceKey = "groupMode_id"
+        static private let groupMode_persistenceKey = "groupMode_id"
+        static private let sortOrder_baseKey = "sortOrder_id"
 
         static var lastKnownGroupMode: Self {
-            if let id = UserDefaults.standard.string(forKey: persistenceKey),
+            if let id = UserDefaults.standard.string(forKey: groupMode_persistenceKey),
                 let mode = Self(rawValue: id)
             {
                 return mode
@@ -61,8 +62,54 @@ extension MainContentPage.ViewModel {
             }
         }
 
-        func persist() {
-            UserDefaults.standard.set(self.id, forKey: Self.persistenceKey)
+        static var lastKnownSortOrder: SortOrder {
+            let sortOrder_persistenceKey = "\(Self.lastKnownGroupMode.id)_\(Self.sortOrder_baseKey)"
+            guard let id = UserDefaults.standard.string(forKey: sortOrder_persistenceKey) else
+            { return .forward }
+
+            switch id {
+            case "reverse":
+                return .reverse
+            case "forward":
+                return .forward
+            default:
+                return .forward
+            }
+        }
+
+        func persist(with sortOrder: SortOrder) {
+            UserDefaults.standard.set(self.id, forKey: Self.groupMode_persistenceKey)
+            let sortOrder_persistenceKey = "\(self.id)_\(Self.sortOrder_baseKey)"
+            UserDefaults.standard.set(sortOrder.displayName, forKey: sortOrder_persistenceKey)
+        }
+    }
+}
+
+extension SortOrder {
+    var identifier: String {
+        switch self {
+        case .forward:
+            "forward"
+        case .reverse:
+            "reverse"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .forward:
+            return "Ascending"
+        case .reverse:
+            return "Descending"
+        }
+    }
+
+
+    func toggle() -> SortOrder {
+        if self == .forward {
+            .reverse
+        } else {
+            .forward
         }
     }
 }

--- a/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
@@ -5,6 +5,7 @@
 //  Created by Jack on 3/22/25.
 //
 
+import OSLog
 import SectionedQuery
 import SwiftData
 import SwiftUI
@@ -67,11 +68,13 @@ extension MainContentPage.ViewModel {
         }
 
         static var lastKnownSortOrder: SortOrder {
-            let sortOrder_persistenceKey = "\(Self.lastKnownGroupMode.id)_\(Self.sortOrder_baseKey)"
+            let sortOrder_persistenceKey = "\(Self.lastKnownGroupMode.id)-\(Self.sortOrder_baseKey)"
             guard let id = UserDefaults.standard.string(forKey: sortOrder_persistenceKey) else {
+                Logger.views.debug("\(#function) failed to read \(sortOrder_persistenceKey)")
                 return .forward
             }
 
+            Logger.views.debug("\(#function) found \(id) for \(sortOrder_persistenceKey)")
             switch id {
             case "reverse":
                 return .reverse
@@ -82,10 +85,16 @@ extension MainContentPage.ViewModel {
             }
         }
 
-        func persist(with sortOrder: SortOrder) {
+        func persist() {
             UserDefaults.standard.set(self.id, forKey: Self.groupMode_persistenceKey)
-            let sortOrder_persistenceKey = "\(self.id)_\(Self.sortOrder_baseKey)"
-            UserDefaults.standard.set(sortOrder.displayName, forKey: sortOrder_persistenceKey)
+        }
+
+        func persist(sortOrder: SortOrder) {
+            let sortOrder_persistenceKey = "\(self.id)-\(Self.sortOrder_baseKey)"
+            UserDefaults.standard.set(sortOrder.identifier, forKey: sortOrder_persistenceKey)
+            Logger.views.debug(
+                "Persisted group mode: \(self.displayName, privacy: .public), sort order: \(sortOrder.identifier, privacy: .public)"
+            )
         }
     }
 }

--- a/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
@@ -34,16 +34,20 @@ extension MainContentPage.ViewModel {
             }
         }
 
-        var sectionQuery: SectionedQuery<String, Bike> {
+        /// Query for Bikes grouped by `self`: either byStatus or byManufacturer
+        /// The sections will be sorted.
+        /// E.g. SortOrder.forward: Giant, Jamis, Specialized (down arrow)
+        ///      SortOrder.reverse: Specialized, Jamis, Giant (up arrow)
+        func sectionQuery(with sortOrder: SortOrder) -> SectionedQuery<String, Bike> {
             switch self {
             case .byStatus:
                 SectionedQuery(
                     \Bike.statusString,
-                    sort: [SortDescriptor(\Bike.statusString)])
+                    sort: [SortDescriptor(\Bike.statusString, order: sortOrder)])
             case .byManufacturer:
                 SectionedQuery(
                     \Bike.manufacturerName,
-                    sort: [SortDescriptor(\Bike.manufacturerName)])
+                    sort: [SortDescriptor(\Bike.manufacturerName, order: sortOrder)])
             }
         }
 
@@ -64,8 +68,9 @@ extension MainContentPage.ViewModel {
 
         static var lastKnownSortOrder: SortOrder {
             let sortOrder_persistenceKey = "\(Self.lastKnownGroupMode.id)_\(Self.sortOrder_baseKey)"
-            guard let id = UserDefaults.standard.string(forKey: sortOrder_persistenceKey) else
-            { return .forward }
+            guard let id = UserDefaults.standard.string(forKey: sortOrder_persistenceKey) else {
+                return .forward
+            }
 
             switch id {
             case "reverse":
@@ -103,7 +108,6 @@ extension SortOrder {
             return "Descending"
         }
     }
-
 
     func toggle() -> SortOrder {
         if self == .forward {

--- a/BikeIndex/ViewModel/MainContent/MainContent+ViewModel.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+ViewModel.swift
@@ -37,12 +37,12 @@ extension MainContentPage {
         /// Will persist after `didSet`.
         var groupMode: GroupMode = GroupMode.lastKnownGroupMode {
             didSet {
-                groupMode.persist(with: sortOrder)
+                groupMode.persist()
             }
         }
         var sortOrder: SortOrder = GroupMode.lastKnownSortOrder {
             didSet {
-                groupMode.persist(with: sortOrder)
+                groupMode.persist(sortOrder: sortOrder)
             }
         }
 

--- a/BikeIndex/ViewModel/MainContent/MainContent+ViewModel.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+ViewModel.swift
@@ -37,7 +37,12 @@ extension MainContentPage {
         /// Will persist after `didSet`.
         var groupMode: GroupMode = GroupMode.lastKnownGroupMode {
             didSet {
-                groupMode.persist()
+                groupMode.persist(with: sortOrder)
+            }
+        }
+        var sortOrder: SortOrder = GroupMode.lastKnownSortOrder {
+            didSet {
+                groupMode.persist(with: sortOrder)
             }
         }
 


### PR DESCRIPTION
# Description

- Add sort order for _groups_ of bikes
- Down arrow ⬇️ uses `Swift.SortOrder.forward`
    - E.g. Giant, Jamis, Specialized
- Up arrow ⬆️ uses `Swift.SortOrder.reverse`
    - E.g.: Specialized, Jamis, Giant

### Preview Screenshot 
<img width="462" alt="Screenshot 2025-05-03 at 17 35 36" src="https://github.com/user-attachments/assets/7f790807-f08a-4bfb-ba3e-91d6eaee1ecb" />
