### PR TITLE
Fix: Acknowledge SwiftUI CachedAsyncImage package

### DIFF
--- a/BikeIndex/Model/Settings/AcknowledgementPackage.swift
+++ b/BikeIndex/Model/Settings/AcknowledgementPackage.swift
@@ -60,6 +60,14 @@ extension AcknowledgementPackage {
             license: .mit,
             copyright: "Copyright © 2023 Thomas Magis-Agosta",
             repository: URL("https://github.com/beechtom/swiftdata-sectionedquery")),
+        AcknowledgementPackage(
+            title: "SwiftUI CachedAsyncImage",
+            license: .mit,
+            copyright: "Copyright © 2021 Lorenzo Fiamingo",
+            repository: URL(
+                "https://github.com/lorenzofiamingo/swiftui-cached-async-image"
+            )
+        ),
     ]
 
     static var gnuAfferoGPLv3Packages: [AcknowledgementPackage] {


### PR DESCRIPTION
# Description

- Follow-up to https://github.com/bikeindex/bike_index_ios/pull/66
- Update acknowledgements to add [SwiftUI CachedAsyncImage](https://swiftpackageindex.com/lorenzofiamingo/swiftui-cached-async-image)