### PR TITLE
Feat: Group bikes by year

### DIFF
--- a/BikeIndex/Model/Bike.swift
+++ b/BikeIndex/Model/Bike.swift
@@ -31,6 +31,11 @@ import SwiftData
     /// Also accepts manufacturer identifier Int
     var manufacturerName: String
     var year: Int?
+    /// SwiftData KeyPaths are used with SectionedQuery to display section titles and mixing
+    /// the types of key paths is very difficult to work-around so we make it queryable
+    /// with a default value of empty string to be over-written by 1) ``Bike/init``
+    /// and 2) ``Bike/year/willSet``
+    var yearString: String = Constants.unknownYear
 
     /// Keyed by `cycle_type_slug`
     var typeOfCycle: BicycleType
@@ -83,6 +88,8 @@ import SwiftData
 
         /// The range of **displayable** years for Bike models aka "inclusive 1900-2026"
         static let displayableYearRange = 1900..<2027
+
+        static let unknownYear = "Unknown"
     }
 
     init(
@@ -116,6 +123,7 @@ import SwiftData
         self.frameColorTertiary = tertiaryColor
         self.manufacturerName = manufacturerName
         self.year = year
+        self.yearString = year.map(String.init) ?? Constants.unknownYear
         self.typeOfCycle = typeOfCycle
         self.typeOfPropulsion = typeOfPropulsion
         self.serial = serial
@@ -162,9 +170,10 @@ import SwiftData
         self[keyPath: keyPath] = value
         if keyPath == \.status {
             statusString = status.rawValue
+        } else if keyPath == \.year {
+            yearString = year.map(String.init) ?? Constants.unknownYear
         }
     }
-
 }
 
 extension Bike {

--- a/BikeIndex/View/MainContent/BikesList.swift
+++ b/BikeIndex/View/MainContent/BikesList.swift
@@ -14,7 +14,7 @@ struct BikesList: View {
     @Binding var path: NavigationPath
     @Binding var fetching: Bool
 
-    @SectionedQuery(\Bike.statusString)
+    @SectionedQuery
     var bikes: SectionedResults<String, Bike>
 
     var group: MainContentPage.ViewModel.GroupMode
@@ -57,6 +57,7 @@ struct BikesList: View {
                             } else {
                                 BikesSection.SectionValue?(nil)
                             }
+                        case .byYear: .byYear(section.id)
                         case .byManufacturer: .byManufacturer(section.id)
                         }
                     if let section {

--- a/BikeIndex/View/MainContent/BikesSection.swift
+++ b/BikeIndex/View/MainContent/BikesSection.swift
@@ -70,6 +70,7 @@ struct BikesSection: View {
 extension BikesSection {
     enum SectionValue {
         case byStatus(BikeStatus)
+        case byYear(String)
         case byManufacturer(String)
 
         var filterPredicate: Predicate<Bike> {
@@ -77,6 +78,10 @@ extension BikesSection {
             case .byStatus(let status):
                 return #Predicate<Bike> { model in
                     model.statusString == status.rawValue
+                }
+            case .byYear(let year):
+                return #Predicate<Bike> { model in
+                    model.yearString == year
                 }
             case .byManufacturer(let manufacturer):
                 return #Predicate<Bike> { model in
@@ -89,6 +94,8 @@ extension BikesSection {
             switch self {
             case .byStatus(let bikeStatus):
                 bikeStatus.rawValue.capitalized
+            case .byYear(let year):
+                year
             case .byManufacturer(let manufacturer):
                 manufacturer
             }

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -135,6 +135,7 @@ struct MainContentPage: View {
             do {
                 let rawJsonData = MockData.sampleBikeJson.data(using: .utf8)!
                 let statuses: [BikeStatus] = Array(repeating: .withOwner, count: 3)
+                let years: [Int?] = [2025, 2020, nil]
                 let manufacturers = [
                     "Giant", "Specialized", "Jamis", "Giant", "Specialized", "Jamis",
                 ]
@@ -146,6 +147,7 @@ struct MainContentPage: View {
                     // but separate the identifiers
                     bike.identifier = index
                     bike.update(keyPath: \.status, to: status)
+                    bike.update(keyPath: \.year, to: years[index])
                     bike.update(keyPath: \.manufacturerName, to: manufacturers[index])
                     print(
                         "Pre-insert bike \(bike.identifier) with \(bike.status.rawValue) / status string = \(bike.statusString)"
@@ -176,6 +178,7 @@ struct MainContentPage: View {
                 let manufacturers = [
                     "Giant", "Specialized", "Jamis", "Giant", "Specialized", "Jamis",
                 ]
+                let years: [Int?] = [2025, 2020, nil]
 
                 for (index, status) in BikeStatus.allCases.enumerated() {
                     let bike = output.modelInstance()
@@ -184,6 +187,7 @@ struct MainContentPage: View {
                     // but separate the identifiers
                     bike.identifier = index
                     bike.update(keyPath: \.status, to: status)
+                    bike.update(keyPath: \.year, to: years[index])
                     bike.update(keyPath: \.manufacturerName, to: manufacturers[index])
                     print(
                         "Pre-insert bike \(bike.identifier) with \(bike.status.rawValue) / status string = \(bike.statusString)"

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -178,7 +178,7 @@ struct MainContentPage: View {
                 let manufacturers = [
                     "Giant", "Specialized", "Jamis", "Giant", "Specialized", "Jamis",
                 ]
-                let years: [Int?] = [2025, 2020, nil]
+                let years: [Int?] = [2025, 2024, 2020, 2015, 2014, nil]
 
                 for (index, status) in BikeStatus.allCases.enumerated() {
                     let bike = output.modelInstance()

--- a/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
@@ -13,6 +13,7 @@ import SwiftUI
 extension MainContentPage.ViewModel {
     enum GroupMode: String, CaseIterable, Identifiable, Equatable {
         case byStatus
+        case byYear
         case byManufacturer
 
         var id: String { rawValue }
@@ -20,9 +21,11 @@ extension MainContentPage.ViewModel {
         var displayName: String {
             switch self {
             case .byStatus:
-                return "Status"
+                "Status"
+            case .byYear:
+                "Year"
             case .byManufacturer:
-                return "Manufacturer"
+                "Manufacturer"
             }
         }
 
@@ -30,21 +33,32 @@ extension MainContentPage.ViewModel {
             switch self {
             case .byStatus:
                 \Bike.statusString
+            case .byYear:
+                \Bike.yearString
             case .byManufacturer:
                 \Bike.manufacturerName
             }
         }
 
-        /// Query for Bikes grouped by `self`: either byStatus or byManufacturer
-        /// The sections will be sorted.
-        /// E.g. SortOrder.forward: Giant, Jamis, Specialized (down arrow)
-        ///      SortOrder.reverse: Specialized, Jamis, Giant (up arrow)
+        /// Query for Bikes grouped by `self`. The sections will be sorted.
+        /// E.g. byManufacturer:
+        ///     SortOrder.forward: Giant, Jamis, Specialized (down arrow)
+        ///     SortOrder.reverse: Specialized, Jamis, Giant (up arrow)
+        /// NOTE: Although the queries _could_ have different types (\Bike.year: Int?) in practice
+        /// these must all use String key paths (or an enum with a String raw value).
+        /// ``BikesSection/SectionValue`` will be used to *display the title* of the section
+        /// and that relies on the key path we provide here to group the sections.
         func sectionQuery(with sortOrder: SortOrder) -> SectionedQuery<String, Bike> {
             switch self {
             case .byStatus:
                 SectionedQuery(
                     \Bike.statusString,
                     sort: [SortDescriptor(\Bike.statusString, order: sortOrder)])
+            case .byYear:
+                SectionedQuery(
+                    \Bike.yearString,
+                    // use Int sorting
+                    sort: [SortDescriptor(\Bike.year, order: sortOrder)])
             case .byManufacturer:
                 SectionedQuery(
                     \Bike.manufacturerName,


### PR DESCRIPTION
# Description

- Add Bike.yearString to use String-keypath queries in SwiftData and SectionedQuery
- Add Bike.year updates for MainContentPage #Previews
- Add GroupdMode.byYear and SectionValue.byYear to enable grouping and display of bikes-by-year

### Screenshots

| Bikes grouped by year | Grouping control |
| -- | -- |
| <img width="461" alt="Screenshot 2025-05-04 at 11 12 10" src="https://github.com/user-attachments/assets/7e6bf675-8013-4619-8883-2fa1e4a6c0fe" /> | <img width="465" alt="Screenshot 2025-05-04 at 11 12 04" src="https://github.com/user-attachments/assets/050a527a-60cd-47af-92a6-58d395da1f56" /> |
