### PR TITLE
Feat: Add info links to 'Register a stolen bike' page

### DIFF
--- a/BikeIndex/Model/Registering/RegisterMode.swift
+++ b/BikeIndex/Model/Registering/RegisterMode.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 enum RegisterMode {
     case myOwnBike
@@ -18,6 +19,15 @@ enum RegisterMode {
             "Enter Bike Details"
         case .myStolenBike:
             "Enter Stolen Bike Details"
+        }
+    }
+
+    var navigationBarDisplayMode: NavigationBarItem.TitleDisplayMode {
+        switch self {
+        case .myOwnBike:
+            .automatic
+        case .myStolenBike:
+            .inline
         }
     }
 }

--- a/BikeIndex/View/Registering/RegisterBikeView.swift
+++ b/BikeIndex/View/Registering/RegisterBikeView.swift
@@ -78,18 +78,7 @@ struct RegisterBikeView: View {
     var body: some View {
         Form {
             if mode == .myStolenBike {
-                Section {
-                    NavigationLink {
-                        NavigableWebView(
-                            constantLink: .stolenBikeFAQ,
-                            host: client.configuration.host
-                        )
-                        .environment(client)
-                    } label: {
-                        Text("⚠️ How to get your stolen bike back")
-                    }
-                }
-
+                StolenBikeInfoSectionView()
             }
 
             // MARK: Serial number
@@ -296,6 +285,7 @@ struct RegisterBikeView: View {
             }
             .disabled(client.userCanRegisterBikes && requiredFieldsNotMet)
         }
+        .navigationBarTitleDisplayMode(mode.navigationBarDisplayMode)
         .navigationTitle(mode.title)
         .onAppear {
             if let user = authenticatedUsers.first?.user {

--- a/BikeIndex/View/Registering/StolenBikeInfoSectionView.swift
+++ b/BikeIndex/View/Registering/StolenBikeInfoSectionView.swift
@@ -1,0 +1,36 @@
+//
+//  StolenBikeInfoSectionView.swift
+//  BikeIndex
+//
+//  Created by Jack on 5/4/25.
+//
+
+import SwiftUI
+
+struct StolenBikeInfoSectionView: View {
+    @Environment(Client.self) var client
+    var body: some View {
+        Section {
+            NavigationLink {
+                NavigableWebView(
+                    constantLink: .stolenBikeWhatToDo,
+                    host: client.configuration.host
+                )
+                .environment(client)
+            } label: {
+                Text("What do to if your bike is stolen")
+            }
+            NavigationLink {
+                NavigableWebView(
+                    constantLink: .stolenBikeFAQ,
+                    host: client.configuration.host
+                )
+                .environment(client)
+            } label: {
+                Text("How to get your stolen bike back")
+            }
+        } header: {
+            Text("⚠️ Information")
+        }
+    }
+}

--- a/BikeIndex/View/Registering/StolenBikeInfoSectionView.swift
+++ b/BikeIndex/View/Registering/StolenBikeInfoSectionView.swift
@@ -18,7 +18,7 @@ struct StolenBikeInfoSectionView: View {
                 )
                 .environment(client)
             } label: {
-                Text("What do to if your bike is stolen")
+                Text("What to do if your bike is stolen")
             }
             NavigationLink {
                 NavigableWebView(

--- a/BikeIndex/View/TextLink.swift
+++ b/BikeIndex/View/TextLink.swift
@@ -43,6 +43,7 @@ enum BikeIndexLink: Identifiable {
     // MARK: General
     case oauthApplications
     case serials
+    case stolenBikeWhatToDo
     case stolenBikeFAQ
     case privacyPolicy
     case termsOfService
@@ -70,7 +71,8 @@ enum BikeIndexLink: Identifiable {
             markdownSource =
                 "Learn more about [How to get your stolen bike back](\(link(base: base)))"
         case .help, .privacyPolicy, .termsOfService, .deleteAccount, .accountUserSettings,
-            .accountPassword, .accountSharingPersonalPage, .accountRegistrationOrganization:
+            .accountPassword, .accountSharingPersonalPage, .accountRegistrationOrganization,
+            .stolenBikeWhatToDo:
             return AttributedString()
         }
 
@@ -97,6 +99,9 @@ enum BikeIndexLink: Identifiable {
         case .serials:
             // https://bikeindex.org/serials
             return "serials"
+        case .stolenBikeWhatToDo:
+            // https://bikeindex.org/stolen
+            return "stolen"
         case .stolenBikeFAQ:
             // https://bikeindex.org/info/how-to-get-your-stolen-bike-back
             return "info/how-to-get-your-stolen-bike-back"

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -198,13 +198,15 @@ final class BikeIndexUITests: XCTestCase {
         _ = registerBikeButton.waitForExistence(timeout: timeout)
         registerBikeButton.tap()
 
-        let goToHowToGetYourBikeBackPage = app.staticTexts.matching(
-            NSPredicate(format: "label BEGINSWITH %@", "⚠️ How to get your stolen bike back"))
-        if goToHowToGetYourBikeBackPage.element.waitForExistence(timeout: timeout) {
-            goToHowToGetYourBikeBackPage.element.tap()
-        } else {
-            XCTFail("Expected markdown link at 'How to get your stolen bike back'")
-        }
+        let whatToDoIfYourBikeIStolenPage = app.buttons["What to do if your bike is stolen"]
+        _ = whatToDoIfYourBikeIStolenPage.waitForExistence(timeout: timeout)
+        whatToDoIfYourBikeIStolenPage.tap()
+
+        back()
+
+        let goToHowToGetYourBikeBackPage = app.buttons["How to get your stolen bike back"]
+        _ = goToHowToGetYourBikeBackPage.waitForExistence(timeout: timeout)
+        goToHowToGetYourBikeBackPage.tap()
 
         back()
     }


### PR DESCRIPTION
# Description

- Add information link to bikeindex.org/stolen above 'how to get your stolen bike back' FAQ link
- Fix navigation bar title mode for stolen bike registration

### Screenshots

| Old | New |
| -- | -- |
| ![simulator_screenshot_CFC28664-BAD3-4EEC-9B06-553442B415F9](https://github.com/user-attachments/assets/90f56114-7d9c-4411-8b21-e9792f20dac7) | ![simulator_screenshot_74669E30-0B62-4AC9-8590-8E40D2A8328A](https://github.com/user-attachments/assets/51f22947-2224-4144-83d6-3477537197e9) |
