### PR TITLE
Fix: Flatten BikesSection.SectionValue into MainContentPage.ViewModel.GroupMode

### DIFF
--- a/BikeIndex/Model/Bike.swift
+++ b/BikeIndex/Model/Bike.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import MapKit
+import OSLog
 import SwiftData
 
 @Model final class Bike {
@@ -128,7 +129,7 @@ import SwiftData
         self.typeOfPropulsion = typeOfPropulsion
         self.serial = serial
         self.status = status
-        self.statusString = status.rawValue
+        self.statusString = status.displayName
         self.stolenCoordinateLatitude = stolenCoordinateLatitude
         self.stolenCoordinateLongitude = stolenCoordinateLongitude
         self.stolenLocation = stolenLocation
@@ -169,7 +170,7 @@ import SwiftData
         print("Bike #\(identifier) updating \(keyPath) to \(value)")
         self[keyPath: keyPath] = value
         if keyPath == \.status {
-            statusString = status.rawValue
+            statusString = status.displayName
         } else if keyPath == \.year {
             yearString = year.map(String.init) ?? Constants.unknownYear
         }

--- a/BikeIndex/Model/BikeStatus.swift
+++ b/BikeIndex/Model/BikeStatus.swift
@@ -14,4 +14,8 @@ enum BikeStatus: String, Codable, CaseIterable {
     case abandoned
     case impounded
     case unregisteredParkingNotification = "unregistered parking notification"
+
+    var displayName: String {
+        rawValue.capitalized
+    }
 }

--- a/BikeIndex/View/MainContent/BikesList.swift
+++ b/BikeIndex/View/MainContent/BikesList.swift
@@ -9,64 +9,51 @@ import SectionedQuery
 import SwiftData
 import SwiftUI
 
+#warning("TODO: Rename to BikesGridContainerView")
 /// Display multiple sections of bikes together
 struct BikesList: View {
     @Binding var path: NavigationPath
     @Binding var fetching: Bool
 
-    @SectionedQuery
-    var bikes: SectionedResults<String, Bike>
-
-    var group: MainContentPage.ViewModel.GroupMode
+    /// The current grouping mode that should be used to section bikes. Ex: byStatus.
+    /// Primary key and combines with sort order for section titles.
+    private var group: MainContentPage.ViewModel.GroupMode
     /// Sort order applies to the sections, not the bikes in each section.
-    var sortOrder: SortOrder
+    /// See ``MainContentPage/ViewModel/GroupMode/sectionQuery(with:)`` to sort the bikes within a section.
+    private var sectionSortOrder: SortOrder
+
+    /// "Output": bikes grouped by a particular section suitable for ordered display.
+    @SectionedQuery
+    private var sections: SectionedResults<String, Bike>
 
     init(
-        path: Binding<NavigationPath>, fetching: Binding<Bool>,
-        group: MainContentPage.ViewModel.GroupMode,
-        sortOrder: SortOrder
+        path: Binding<NavigationPath>,
+        fetching: Binding<Bool>,
+        sectionGroup group: MainContentPage.ViewModel.GroupMode,
+        sectionSortOrder: SortOrder
     ) {
         _path = path
         _fetching = fetching
         self.group = group
-        self.sortOrder = sortOrder
+        self.sectionSortOrder = sectionSortOrder
 
-        _bikes = group.sectionQuery(with: sortOrder)
+        _sections = group.sectionQuery(with: sectionSortOrder)
     }
 
     var body: some View {
         if fetching {
             ContentUnavailableView("Fetching bikes…", systemImage: "bicycle.circle")
                 .padding()
-        } else if bikes.isEmpty {
+        } else if sections.isEmpty {
             ContentUnavailableView("No bikes registered", systemImage: "bicycle.circle.fill")
                 .padding()
         } else {
             ProportionalLazyVGrid(pinnedViews: [.sectionHeaders]) {
-                ForEach(bikes) { section in
-                    /// Map the broad group (byStatus, byManufacturer)
-                    /// to a _specific_ status or manufacturer to display in _this_ section.
-                    /// Use an optional SectionValue because the ``BikeStatus`` has to map
-                    /// from a string (we can search on ``Bike/statusString`` but **not** Bike.status
-                    /// so there could be a BikeStatus(rawValue:) initializer that fails.
-                    let section: BikesSection.SectionValue? =
-                        switch group {
-                        case .byStatus:
-                            if let status = BikeStatus(rawValue: section.id) {
-                                BikesSection.SectionValue.byStatus(status)
-                            } else {
-                                BikesSection.SectionValue?(nil)
-                            }
-                        case .byYear: .byYear(section.id)
-                        case .byManufacturer: .byManufacturer(section.id)
-                        }
-                    if let section {
-                        BikesSection(
-                            path: $path,
-                            section: section)
-                    } else {
-                        Text("Error rendering section")
-                    }
+                ForEach(sections) { section in
+                    BikesSection(
+                        path: $path,
+                        section: section.id,
+                        bikes: section.elements)  // aka section.bikes
                 }
             }
         }

--- a/BikeIndex/View/MainContent/BikesSection.swift
+++ b/BikeIndex/View/MainContent/BikesSection.swift
@@ -8,20 +8,23 @@
 import SwiftData
 import SwiftUI
 
+#warning("TODO: Rename to BikesGridSectionView")
 struct BikesSection: View {
+    typealias GroupMode = MainContentPage.ViewModel.GroupMode
+
     @Binding var path: NavigationPath
-    private(set) var section: SectionValue
-    @Query private var bikes: [Bike]
+    var section: String
+    private var bikes: [Bike]
     @AppStorage
     private var isExpanded: Bool
 
-    init(path: Binding<NavigationPath>, section: SectionValue) {
+    init(path: Binding<NavigationPath>, section: String, bikes: [Bike]) {
         self._path = path
+        self.bikes = bikes
         self.section = section
-        _bikes = Query(filter: section.filterPredicate)
         /// Track expanded state _for each section_
         _isExpanded = AppStorage(
-            wrappedValue: true, "BikesSection.isExpanded.\(section.displayName)")
+            wrappedValue: true, "BikesSection.isExpanded.\(section)")
     }
 
     var body: some View {
@@ -42,7 +45,7 @@ struct BikesSection: View {
                 }
             } label: {
                 ZStack {
-                    Text(section.displayName)
+                    Text(section)
                         .padding([.top, .bottom], 4)
                         .frame(maxWidth: .infinity)
                         .font(.headline)
@@ -57,48 +60,12 @@ struct BikesSection: View {
                 .background(.ultraThinMaterial)
             }
             .accessibilityValue("\(isExpanded ? "Expanded" : "Collapsed")")
-            .accessibilityIdentifier("Section toggle \(section.displayName)")
+            .accessibilityIdentifier("Section toggle \(section)")
             .accessibilityHint(
-                "\(isExpanded ? "Collapse" : "Expand") section for \(section.displayName)"
+                "\(isExpanded ? "Collapse" : "Expand") section for \(section)"
             )
             .buttonStyle(.plain)
             .padding([.top, .bottom], 2)
-        }
-    }
-}
-
-extension BikesSection {
-    enum SectionValue {
-        case byStatus(BikeStatus)
-        case byYear(String)
-        case byManufacturer(String)
-
-        var filterPredicate: Predicate<Bike> {
-            switch self {
-            case .byStatus(let status):
-                return #Predicate<Bike> { model in
-                    model.statusString == status.rawValue
-                }
-            case .byYear(let year):
-                return #Predicate<Bike> { model in
-                    model.yearString == year
-                }
-            case .byManufacturer(let manufacturer):
-                return #Predicate<Bike> { model in
-                    model.manufacturerName == manufacturer
-                }
-            }
-        }
-
-        var displayName: String {
-            switch self {
-            case .byStatus(let bikeStatus):
-                bikeStatus.rawValue.capitalized
-            case .byYear(let year):
-                year
-            case .byManufacturer(let manufacturer):
-                manufacturer
-            }
         }
     }
 }
@@ -111,7 +78,8 @@ extension BikesSection {
             ProportionalLazyVGrid {
                 BikesSection(
                     path: $navigationPath,
-                    section: .byStatus(status))
+                    section: status.displayName,
+                    bikes: [])
             }
         }
     }

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -34,8 +34,8 @@ struct MainContentPage: View {
                 BikesList(
                     path: $viewModel.path,
                     fetching: $viewModel.fetching,
-                    group: viewModel.groupMode,
-                    sortOrder: viewModel.sortOrder)
+                    sectionGroup: viewModel.groupMode,
+                    sectionSortOrder: viewModel.sortOrder)
             }
             .toolbar {
                 MainToolbar(


### PR DESCRIPTION
# Description

- Change Bike.statusString enum-predicate-workaround to use BikeStatus.displayName to avoid later manipulation
- Clarify fields in BikesList (aka BikesGridContainerView)
- Remove mapping where BikesList/BikesGridContainerView would convert GroupMode values to BikesSection.SectionValue values because:
	1. Previously this was used to guard against possibly-nil Bike.status: BikeStatus values but that is a required field
	2. Previously this was used to convert the Bike.statusString section query back to a proper BikeStatus and retrieve the display name -- but now this all occurs directly when Bike.statusString is written
	3. This also caused BikesSection/BikesGridSectionView to run a second query after the BikesList/BikesGridContainerView had already run a query!
- Remove BikesSection.SectionValue
- Thus, all BikesSection (aka BikesGridSectionView) header titles are pulled from the data. Any remappings (statusString, yearString) occur in Bike.swift
- Thus, BikesSection no longer needs its own @Query and we can reduce reading from SwiftData because the work was already done