### PR TITLE
Fix: Clean up bikes grid names

### DIFF
--- a/BikeIndex/Model/Registering/BikeRegistration+Propulsion.swift
+++ b/BikeIndex/Model/Registering/BikeRegistration+Propulsion.swift
@@ -10,7 +10,6 @@ import Foundation
 extension BikeRegistration {
     /// Track View state with validation. This model should be composed with BikeRegistration and reduce the complexity in ``Bike`` and ``BikeRegistration``.
     /// Used by BikeRegistration to POST to API endpoints
-    // TODO: Check if we can invoke this from BikeRegistration.encode -> Propulsion.encode and remove duplication and the "wrong" level of abstraction to perform encoding
     struct Propulsion {
 
         /// ``hasThrottle`` and ``hasPedalAssist`` can only be true when ``isElectric`` is true.

--- a/BikeIndex/View/MainContent/BikesGridContainerView.swift
+++ b/BikeIndex/View/MainContent/BikesGridContainerView.swift
@@ -49,7 +49,7 @@ struct BikesGridContainerView: View {
         } else {
             ProportionalLazyVGrid(pinnedViews: [.sectionHeaders]) {
                 ForEach(sections) { section in
-                    BikesSection(
+                    BikesGridSectionView(
                         path: $path,
                         section: section.id,
                         bikes: section.elements)  // aka section.bikes

--- a/BikeIndex/View/MainContent/BikesGridContainerView.swift
+++ b/BikeIndex/View/MainContent/BikesGridContainerView.swift
@@ -1,5 +1,5 @@
 //
-//  BikesList.swift
+//  BikesGridContainerView.swift
 //  BikeIndex
 //
 //  Created by Jack on 3/23/25.
@@ -9,9 +9,8 @@ import SectionedQuery
 import SwiftData
 import SwiftUI
 
-#warning("TODO: Rename to BikesGridContainerView")
 /// Display multiple sections of bikes together
-struct BikesList: View {
+struct BikesGridContainerView: View {
     @Binding var path: NavigationPath
     @Binding var fetching: Bool
 

--- a/BikeIndex/View/MainContent/BikesGridSectionView.swift
+++ b/BikeIndex/View/MainContent/BikesGridSectionView.swift
@@ -1,5 +1,5 @@
 //
-//  BikesSection.swift
+//  BikesGridSectionView.swift
 //  BikeIndex
 //
 //  Created by Jack on 3/2/25.
@@ -8,8 +8,7 @@
 import SwiftData
 import SwiftUI
 
-#warning("TODO: Rename to BikesGridSectionView")
-struct BikesSection: View {
+struct BikesGridSectionView: View {
     typealias GroupMode = MainContentPage.ViewModel.GroupMode
 
     @Binding var path: NavigationPath
@@ -24,7 +23,7 @@ struct BikesSection: View {
         self.section = section
         /// Track expanded state _for each section_
         _isExpanded = AppStorage(
-            wrappedValue: true, "BikesSection.isExpanded.\(section)")
+            wrappedValue: true, "BikesGridSectionView.isExpanded.\(section)")
     }
 
     var body: some View {
@@ -76,7 +75,7 @@ struct BikesSection: View {
     NavigationStack {
         ScrollView {
             ProportionalLazyVGrid {
-                BikesSection(
+                BikesGridSectionView(
                     path: $navigationPath,
                     section: status.displayName,
                     bikes: [])

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -16,7 +16,7 @@ struct MainContentPage: View {
     @Environment(Client.self) var client
 
     /// ViewModel for state management.
-    /// Forwards dynamic query changes to ``BikesList`` to support dynamic grouping selection.
+    /// Forwards dynamic query changes to ``BikesGridContainerView`` to support dynamic grouping selection.
     @State private var viewModel = ViewModel()
 
     var body: some View {
@@ -31,7 +31,7 @@ struct MainContentPage: View {
                     }
                 }
 
-                BikesList(
+                BikesGridContainerView(
                     path: $viewModel.path,
                     fetching: $viewModel.fetching,
                     sectionGroup: viewModel.groupMode,

--- a/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
@@ -46,8 +46,8 @@ extension MainContentPage.ViewModel {
         ///     SortOrder.reverse: Specialized, Jamis, Giant (up arrow)
         /// NOTE: Although the queries _could_ have different types (\Bike.year: Int?) in practice
         /// these must all use String key paths (or an enum with a String raw value).
-        /// ``BikesSection/SectionValue`` will be used to *display the title* of the section
-        /// and that relies on the key path we provide here to group the sections.
+        /// Unfortunately this requires shadowing Enum and Int fields
+        /// with String fields but hopefully this improves in iOS 19.
         func sectionQuery(with sortOrder: SortOrder) -> SectionedQuery<String, Bike> {
             switch self {
             case .byStatus:


### PR DESCRIPTION
# Description

- Rename BikesList to BikesGridContainerView
- Rename BikesSection to BikesGridSectionView
- Remove old todo comment