### PR TITLE
Feat: Data layer for QR sticker scan history

### DIFF
--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -45,27 +45,19 @@ struct BikeIndexApp: App {
                 MainContentPage()
                     .tint(Color.accentColor)
                     .onOpenURL { url in
-                        client.deeplinkManager = DeeplinkManager(
-                            host: client.hostProvider,
-                            scannedURL: url)
+                        client.deeplinkManager.scan(url: url)
                     }
                     .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
-                        client.deeplinkManager = DeeplinkManager(
-                            host: client.hostProvider,
-                            scannedURL: userActivity.webpageURL)
+                        client.deeplinkManager.scan(url: userActivity.webpageURL)
                     }
             } else {
                 AuthView()
                     .tint(Color.accentColor)
                     .onOpenURL { url in
-                        client.deeplinkManager = DeeplinkManager(
-                            host: client.hostProvider,
-                            scannedURL: url)
+                        client.deeplinkManager.scan(url: url)
                     }
                     .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
-                        client.deeplinkManager = DeeplinkManager(
-                            host: client.hostProvider,
-                            scannedURL: userActivity.webpageURL)
+                        client.deeplinkManager.scan(url: userActivity.webpageURL)
                     }
 
             }

--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -71,7 +71,7 @@ struct BikeIndexApp: App {
 }
 
 @MainActor
-class ScannedBikesViewModel {
+struct ScannedBikesViewModel {
     let context: ModelContext
     let client: Client
 

--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -26,6 +26,7 @@ struct BikeIndexApp: App {
             User.self,
             AuthenticatedUser.self,
             AutocompleteManufacturer.self,
+            // TODO: Add ScannedBike
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
@@ -45,24 +46,32 @@ struct BikeIndexApp: App {
                 MainContentPage()
                     .tint(Color.accentColor)
                     .onOpenURL { url in
-                        client.deeplinkManager.scan(url: url)
+                        handleDeeplink(url)
                     }
                     .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
-                        client.deeplinkManager.scan(url: userActivity.webpageURL)
+                        handleDeeplink(userActivity.webpageURL)
                     }
             } else {
                 AuthView()
                     .tint(Color.accentColor)
                     .onOpenURL { url in
-                        client.deeplinkManager.scan(url: url)
+                        handleDeeplink(url)
                     }
                     .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
-                        client.deeplinkManager.scan(url: userActivity.webpageURL)
+                        handleDeeplink(userActivity.webpageURL)
                     }
 
             }
         }
         .environment(client)
         .modelContainer(sharedModelContainer)
+    }
+
+    private func handleDeeplink(_ url: URL?) {
+        let scanResult = client.deeplinkManager.scan(url: url)
+        if let sticker = scanResult?.scannedBike {
+            // Persist to SwiftData after previous changes have more confidence.
+//            sharedModelContainer.mainContext.insert(sticker)
+        }
     }
 }

--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -12,31 +12,11 @@ import OSLog
 @main
 struct BikeIndexApp: App {
     /// Create a Client instance for stateful networking.
-    @State private var client: Client = {
-        do {
-            return try Client()
-        } catch {
-            fatalError(error.localizedDescription)
-        }
-    }()
-
+    @State private var client: Client
     /// Set up SwiftData
-    var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            Bike.self,
-            User.self,
-            AuthenticatedUser.self,
-            AutocompleteManufacturer.self,
-            ScannedBike.self, // QR sticker history
-        ])
-        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-
-        do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
-        } catch {
-            fatalError("Could not create ModelContainer: \(error)")
-        }
-    }()
+    var sharedModelContainer: ModelContainer
+    ///
+    var scannedBikesViewModel: ScannedBikesViewModel
 
     /// Set up App
     /// NOTE: MainContentPage and AuthView **each** implement their own universal link handling.
@@ -47,19 +27,19 @@ struct BikeIndexApp: App {
                 MainContentPage()
                     .tint(Color.accentColor)
                     .onOpenURL { url in
-                        handleDeeplink(url)
+                        scannedBikesViewModel.handleDeeplink(url)
                     }
                     .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
-                        handleDeeplink(userActivity.webpageURL)
+                        scannedBikesViewModel.handleDeeplink(userActivity.webpageURL)
                     }
             } else {
                 AuthView()
                     .tint(Color.accentColor)
                     .onOpenURL { url in
-                        handleDeeplink(url)
+                        scannedBikesViewModel.handleDeeplink(url)
                     }
                     .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { userActivity in
-                        handleDeeplink(userActivity.webpageURL)
+                        scannedBikesViewModel.handleDeeplink(userActivity.webpageURL)
                     }
 
             }
@@ -68,29 +48,61 @@ struct BikeIndexApp: App {
         .modelContainer(sharedModelContainer)
     }
 
-    private func handleDeeplink(_ url: URL?) {
+    init() {
+        let client = try! Client()
+        self.client = client
+
+        let schema = Schema([
+            Bike.self,
+            User.self,
+            AuthenticatedUser.self,
+            AutocompleteManufacturer.self,
+            ScannedBike.self, // QR sticker history
+        ])
+        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+
+        self.sharedModelContainer = try! ModelContainer(for: schema, configurations: [modelConfiguration])
+
+        self.scannedBikesViewModel = .init(
+            context: sharedModelContainer.mainContext,
+            client: client
+        )
+    }
+}
+
+@MainActor
+class ScannedBikesViewModel {
+    let context: ModelContext
+    let client: Client
+
+    init(context: ModelContext, client: Client) {
+        self.context = context
+        self.client = client
+    }
+
+    func handleDeeplink(_ url: URL?) {
         let scanResult = client.deeplinkManager.scan(url: url)
         if let sticker = scanResult?.scannedBike {
             do {
-                let mainContext = sharedModelContainer.mainContext
-                try mainContext.transaction {
+                try context.transaction {
                     // 1. Save the latest scanned bike sticker
-                    mainContext.insert(sticker)
+                    context.insert(sticker)
 
                     // 2. Purge any sticker outside of:
                     //      - scanned in the last 2 weeks
                     //      - scanned before the 10-most-recent
+                    let twoWeeksAgo = Date().addingTimeInterval(-60 * 60 * 24 * 14)
                     let bikesScannedInTheLastTwoWeeks = #Predicate<ScannedBike> { model in
-                        model.createdAt > Date().addingTimeInterval(-60 * 60 * 24 * 14)
+                        model.createdAt > twoWeeksAgo
                     }
                     let sortByCreatedAt = SortDescriptor(\ScannedBike.createdAt,
                                                           order: .forward)
                     var fetchDescriptor = FetchDescriptor(predicate: bikesScannedInTheLastTwoWeeks,
                                                           sortBy: [sortByCreatedAt])
                     fetchDescriptor.fetchLimit = 10
-                    let tenMostRecentStickers = try mainContext.fetchIdentifiers(fetchDescriptor)
+                    let tenMostRecentStickers = try context.fetchIdentifiers(fetchDescriptor)
 
-                    try mainContext.delete(model: ScannedBike.self,
+                    try context.delete(model: ScannedBike.self,
                                            where: #Predicate<ScannedBike> { model in
                         tenMostRecentStickers.contains(model.id) == false
                     })

--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -77,42 +77,4 @@ struct BikeIndexApp: App {
     }
 }
 
-@MainActor
-struct ScannedBikesViewModel {
-    let context: ModelContext
-    let client: Client
 
-    init(context: ModelContext, client: Client) {
-        self.context = context
-        self.client = client
-    }
-
-    func persist(sticker: ScannedBike) throws {
-        // 1. Save the latest scanned bike sticker
-        context.insert(sticker)
-        try context.save()
-
-        // 2. Purge any sticker outside of:
-        //      - scanned in the last 2 weeks
-        //      - scanned before the 10-most-recent
-        let twoWeeksAgo = Date().addingTimeInterval(-60 * 60 * 24 * 14)
-        let bikesScannedInTheLastTwoWeeks = #Predicate<ScannedBike> { model in
-            model.createdAt > twoWeeksAgo
-        }
-
-        var fetchDescriptor = FetchDescriptor<ScannedBike>(
-            predicate: bikesScannedInTheLastTwoWeeks,
-            sortBy: [SortDescriptor(\.createdAt, order: .forward)])
-
-
-        fetchDescriptor.fetchLimit = 10
-        // Cannot use fetchIdentifiers _if_ the FetchDescriptor has a `sortBy` on a non-identifier field.
-        let tenMostRecentStickers = try context.fetch(fetchDescriptor)
-            .map(\.persistentModelID)
-
-        try context.delete(model: ScannedBike.self,
-                           where: #Predicate<ScannedBike> { model in
-            tenMostRecentStickers.contains(model.persistentModelID) == false
-        })
-    }
-}

--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -5,9 +5,9 @@
 //  Created by Jack on 11/18/23.
 //
 
+import OSLog
 import SwiftData
 import SwiftUI
-import OSLog
 
 @main
 struct BikeIndexApp: App {
@@ -64,11 +64,12 @@ struct BikeIndexApp: App {
             User.self,
             AuthenticatedUser.self,
             AutocompleteManufacturer.self,
-            ScannedBike.self, // QR sticker history
+            ScannedBike.self,  // QR sticker history
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
-        self.sharedModelContainer = try! ModelContainer(for: schema, configurations: [modelConfiguration])
+        self.sharedModelContainer = try! ModelContainer(
+            for: schema, configurations: [modelConfiguration])
 
         self.scannedBikesViewModel = .init(
             context: sharedModelContainer.mainContext,
@@ -76,5 +77,3 @@ struct BikeIndexApp: App {
         )
     }
 }
-
-

--- a/BikeIndex/Model/Deeplinks/DeeplinkManager.swift
+++ b/BikeIndex/Model/Deeplinks/DeeplinkManager.swift
@@ -12,63 +12,15 @@ final class DeeplinkManager: Identifiable {
     let hostProvider: HostProvider
     var scannedBike: ScannedBike?
 
-    init(host: HostProvider, scannedURL: URL? = nil) {
+    /// Only one ``DeeplinkManager`` should be instantiated.
+    init(host: HostProvider) {
         self.hostProvider = host
-        self.scannedBike = ScannedBike(
-            host: host,
-            url: scannedURL)
     }
-}
 
-struct ScannedBike: Equatable, Identifiable {
-    var id: URL { url }
-
-    var sticker: Sticker
-
-    var url: URL
-}
-
-extension ScannedBike {
-    /// Try to initialize a ScannedBike from a sticker.
-    /// URLs will be bikes/scanned/:id and _may_ start with bikeindex:// (this is useful for development and testing).
-    /// NOTE: Deeplinks will remove the second `:` from `bikeindex://https://bikeindex...`
-    /// - Parameters:
-    ///   - host: Configured host from xcconfig project config that determines the base URL for all API requests. Usually bikeindex.org/
-    ///   - inputUrl: The scanned bike sticker, expected in formats
-    ///     - bikeindex://{host}/bikes/scanned/:id
-    ///     - {host}/bikes/scanned/:id
-    init?(host provider: HostProvider, url inputUrl: URL?) {
-        guard let inputUrl else { return nil }
-        let inputPrefixTrimmed = String(inputUrl.absoluteString.trimmingPrefix("bikeindex://"))
-        let inputCorrectedBase = inputPrefixTrimmed.replacingOccurrences(
-            of: "https//", with: "http://")
-
-        guard let components = URLComponents(string: inputCorrectedBase),
-            let url = components.url,
-            components.host == provider.host.host()
-        else {
-            print("ScannedBike.init failed on nil URL input. Found \(inputCorrectedBase)")
-            return nil
+    /// Every URL scan should go through this function
+    func scan(url: URL?) {
+        if let scannedBike = ScannedBike(host: hostProvider, url: url) {
+            self.scannedBike = scannedBike
         }
-
-        let identifier = url.lastPathComponent
-
-        let givenPathComponents = url.pathComponents
-        let expectedPathComponents = ["/", "bikes", "scanned", identifier]
-
-        guard givenPathComponents == expectedPathComponents else {
-            print("ScannedBike.init failed to find bikes/scanned/:id")
-            return nil
-        }
-
-        self.url = url
-        self.sticker = Sticker(identifier: identifier)
-
     }
-}
-
-/// QR Code Identifiers are used in the format [A-Z]\d{5}
-/// Example: https://bikeindex.org/bikes/scanned/A40340
-struct Sticker: Equatable {
-    var identifier: String
 }

--- a/BikeIndex/Model/Deeplinks/DeeplinkManager.swift
+++ b/BikeIndex/Model/Deeplinks/DeeplinkManager.swift
@@ -10,6 +10,8 @@ import Foundation
 @Observable
 final class DeeplinkManager: Identifiable {
     let hostProvider: HostProvider
+    /// Keep only 1 active QR scanned bike for immediate display in the UI.
+    /// This is forgetful and does not care about scan history.
     var scannedBike: ScannedBike?
 
     /// Only one ``DeeplinkManager`` should be instantiated.
@@ -18,9 +20,16 @@ final class DeeplinkManager: Identifiable {
     }
 
     /// Every URL scan should go through this function
-    func scan(url: URL?) {
+    func scan(url: URL?) -> DeeplinkResult? {
         if let scannedBike = ScannedBike(host: hostProvider, url: url) {
             self.scannedBike = scannedBike
+            return DeeplinkResult(scannedBike: scannedBike)
+        } else {
+            return nil
         }
     }
+}
+
+struct DeeplinkResult {
+    let scannedBike: ScannedBike?
 }

--- a/BikeIndex/Model/Deeplinks/ScannedBike.swift
+++ b/BikeIndex/Model/Deeplinks/ScannedBike.swift
@@ -1,0 +1,65 @@
+//
+//  ScannedBike.swift
+//  BikeIndex
+//
+//  Created by Jack on 5/11/25.
+//
+
+import Foundation
+import SwiftData
+
+/// QR Code Identifiers are used in the format [A-Z]\d{5}
+/// Example: https://bikeindex.org/bikes/scanned/A40340
+struct Sticker: Equatable {
+    var identifier: String
+
+    init(identifier: String) {
+        self.identifier = identifier
+    }
+}
+
+struct ScannedBike: Equatable, Identifiable {
+    var id: URL { url }
+
+    var sticker: Sticker
+
+    var url: URL
+}
+
+extension ScannedBike {
+    /// Try to initialize a ScannedBike from a sticker.
+    /// URLs will be bikes/scanned/:id and _may_ start with bikeindex:// (this is useful for development and testing).
+    /// NOTE: Deeplinks will remove the second `:` from `bikeindex://https://bikeindex...`
+    /// - Parameters:
+    ///   - host: Configured host from xcconfig project config that determines the base URL for all API requests. Usually bikeindex.org/
+    ///   - inputUrl: The scanned bike sticker, expected in formats
+    ///     - bikeindex://{host}/bikes/scanned/:id
+    ///     - {host}/bikes/scanned/:id
+    init?(host provider: HostProvider, url inputUrl: URL?) {
+        guard let inputUrl else { return nil }
+        let inputPrefixTrimmed = String(inputUrl.absoluteString.trimmingPrefix("bikeindex://"))
+        let inputCorrectedBase = inputPrefixTrimmed.replacingOccurrences(
+            of: "https//", with: "http://")
+
+        guard let components = URLComponents(string: inputCorrectedBase),
+            let url = components.url,
+            components.host == provider.host.host()
+        else {
+            print("ScannedBike.init failed on nil URL input. Found \(inputCorrectedBase)")
+            return nil
+        }
+
+        let identifier = url.lastPathComponent
+
+        let givenPathComponents = url.pathComponents
+        let expectedPathComponents = ["/", "bikes", "scanned", identifier]
+
+        guard givenPathComponents == expectedPathComponents else {
+            print("ScannedBike.init failed to find bikes/scanned/:id")
+            return nil
+        }
+
+        self.url = url
+        self.sticker = Sticker(identifier: identifier)
+    }
+}

--- a/BikeIndex/Model/Deeplinks/ScannedBike.swift
+++ b/BikeIndex/Model/Deeplinks/ScannedBike.swift
@@ -18,6 +18,8 @@ class ScannedBike: Equatable, Identifiable {
 
     var url: URL
 
+    var createdAt: Date = Date()
+
     /// Designated initializer only for SwiftData.
     init(sticker: String, url: URL) {
         self.sticker = sticker

--- a/BikeIndex/Model/Deeplinks/ScannedBike.swift
+++ b/BikeIndex/Model/Deeplinks/ScannedBike.swift
@@ -8,22 +8,21 @@
 import Foundation
 import SwiftData
 
-/// QR Code Identifiers are used in the format [A-Z]\d{5}
-/// Example: https://bikeindex.org/bikes/scanned/A40340
-struct Sticker: Equatable {
-    var identifier: String
-
-    init(identifier: String) {
-        self.identifier = identifier
-    }
-}
-
-struct ScannedBike: Equatable, Identifiable {
+@Model
+class ScannedBike: Equatable, Identifiable {
     var id: URL { url }
 
-    var sticker: Sticker
+    /// QR Code Identifiers are used in the format [A-Z]\d{5}
+    /// Example: https://bikeindex.org/bikes/scanned/A40340
+    var sticker: String
 
     var url: URL
+
+    /// Designated initializer only for SwiftData.
+    init(sticker: String, url: URL) {
+        self.sticker = sticker
+        self.url = url
+    }
 }
 
 extension ScannedBike {
@@ -35,7 +34,7 @@ extension ScannedBike {
     ///   - inputUrl: The scanned bike sticker, expected in formats
     ///     - bikeindex://{host}/bikes/scanned/:id
     ///     - {host}/bikes/scanned/:id
-    init?(host provider: HostProvider, url inputUrl: URL?) {
+    convenience init?(host provider: HostProvider, url inputUrl: URL?) {
         guard let inputUrl else { return nil }
         let inputPrefixTrimmed = String(inputUrl.absoluteString.trimmingPrefix("bikeindex://"))
         let inputCorrectedBase = inputPrefixTrimmed.replacingOccurrences(
@@ -59,7 +58,6 @@ extension ScannedBike {
             return nil
         }
 
-        self.url = url
-        self.sticker = Sticker(identifier: identifier)
+        self.init(sticker: identifier, url: url)
     }
 }

--- a/BikeIndex/Model/Deeplinks/ScannedBike.swift
+++ b/BikeIndex/Model/Deeplinks/ScannedBike.swift
@@ -18,12 +18,13 @@ class ScannedBike: Equatable, Identifiable {
 
     var url: URL
 
-    var createdAt: Date = Date()
+    var createdAt: Date
 
     /// Designated initializer only for SwiftData.
-    init(sticker: String, url: URL) {
+    init(sticker: String, url: URL, createdAt: Date = Date()) {
         self.sticker = sticker
         self.url = url
+        self.createdAt = createdAt
     }
 }
 

--- a/BikeIndex/View/Deeplinks/ScannedBikePage.swift
+++ b/BikeIndex/View/Deeplinks/ScannedBikePage.swift
@@ -46,7 +46,7 @@ extension ScannedBikePage {
         var onDisappear: MainContent?
 
         var title: String {
-            scan.sticker.identifier
+            scan.sticker
         }
 
         init(scan: ScannedBike, path: NavigationPath, dismiss: @escaping () -> Void) {

--- a/BikeIndex/View/Onboarding/AuthSignInView.swift
+++ b/BikeIndex/View/Onboarding/AuthSignInView.swift
@@ -42,7 +42,7 @@ struct AuthSignInView: View {
                     /// the user decides to dismiss it.
                     if let scan = newValue, navigator.wkWebView?.url != scan.url {
                         navigator.wkWebView?.load(URLRequest(url: scan.url))
-                        title = scan.sticker.identifier
+                        title = scan.sticker
                     }
                 }
             )

--- a/BikeIndex/ViewModel/ScannedBikesViewModel.swift
+++ b/BikeIndex/ViewModel/ScannedBikesViewModel.swift
@@ -5,10 +5,9 @@
 //  Created by Jack on 5/11/25.
 //
 
-
+import OSLog
 import SwiftData
 import SwiftUI
-import OSLog
 
 @MainActor
 struct ScannedBikesViewModel {
@@ -27,7 +26,9 @@ struct ScannedBikesViewModel {
 
         // 2. Purge any sticker outside of:
         //      - scanned in the last 2 weeks
-        //      - scanned before the 10-most-recent
+        //      - scanned in the 10-most-recent
+        // Ex: The 11th sticker scan will be forgotten.
+        // Ex: A sticker scanned 15 days ago will be forgotten.
         let twoWeeksAgo = Date().addingTimeInterval(-60 * 60 * 24 * 14)
         let bikesScannedInTheLastTwoWeeks = #Predicate<ScannedBike> { model in
             model.createdAt > twoWeeksAgo
@@ -37,16 +38,15 @@ struct ScannedBikesViewModel {
             predicate: bikesScannedInTheLastTwoWeeks,
             sortBy: [SortDescriptor(\.createdAt, order: .forward)])
 
-        print("Saving sticker created at \(sticker.createdAt.timeIntervalSince1970) vs. \(twoWeeksAgo.timeIntervalSince1970). createdAt > twoWeeksAgo = \(sticker.createdAt > twoWeeksAgo)")
-
         fetchDescriptor.fetchLimit = 10
         // Cannot use fetchIdentifiers _if_ the FetchDescriptor has a `sortBy` on a non-identifier field.
         let tenMostRecentStickers = try context.fetch(fetchDescriptor)
             .map(\.persistentModelID)
 
-        try context.delete(model: ScannedBike.self,
-                           where: #Predicate<ScannedBike> { model in
-            tenMostRecentStickers.contains(model.persistentModelID) == false
-        })
+        try context.delete(
+            model: ScannedBike.self,
+            where: #Predicate<ScannedBike> { model in
+                tenMostRecentStickers.contains(model.persistentModelID) == false
+            })
     }
 }

--- a/BikeIndex/ViewModel/ScannedBikesViewModel.swift
+++ b/BikeIndex/ViewModel/ScannedBikesViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  ScannedBikesViewModel.swift
+//  BikeIndex
+//
+//  Created by Jack on 5/11/25.
+//
+
+
+import SwiftData
+import SwiftUI
+import OSLog
+
+@MainActor
+struct ScannedBikesViewModel {
+    let context: ModelContext
+    let client: Client
+
+    init(context: ModelContext, client: Client) {
+        self.context = context
+        self.client = client
+    }
+
+    func persist(sticker: ScannedBike) throws {
+        // 1. Save the latest scanned bike sticker
+        context.insert(sticker)
+        try context.save()
+
+        // 2. Purge any sticker outside of:
+        //      - scanned in the last 2 weeks
+        //      - scanned before the 10-most-recent
+        let twoWeeksAgo = Date().addingTimeInterval(-60 * 60 * 24 * 14)
+        let bikesScannedInTheLastTwoWeeks = #Predicate<ScannedBike> { model in
+            model.createdAt > twoWeeksAgo
+        }
+
+        var fetchDescriptor = FetchDescriptor<ScannedBike>(
+            predicate: bikesScannedInTheLastTwoWeeks,
+            sortBy: [SortDescriptor(\.createdAt, order: .forward)])
+
+        print("Saving sticker created at \(sticker.createdAt.timeIntervalSince1970) vs. \(twoWeeksAgo.timeIntervalSince1970). createdAt > twoWeeksAgo = \(sticker.createdAt > twoWeeksAgo)")
+
+        fetchDescriptor.fetchLimit = 10
+        // Cannot use fetchIdentifiers _if_ the FetchDescriptor has a `sortBy` on a non-identifier field.
+        let tenMostRecentStickers = try context.fetch(fetchDescriptor)
+            .map(\.persistentModelID)
+
+        try context.delete(model: ScannedBike.self,
+                           where: #Predicate<ScannedBike> { model in
+            tenMostRecentStickers.contains(model.persistentModelID) == false
+        })
+    }
+}

--- a/UnitTests/AuthInterceptorTests.swift
+++ b/UnitTests/AuthInterceptorTests.swift
@@ -13,6 +13,7 @@ import WebKit
 @testable import BikeIndex
 
 /// Tests for
+@MainActor
 struct AuthInterceptorTests {
 
     let hostProvider = HostProvider(host: URL("https://bikeindex.org"))
@@ -26,8 +27,8 @@ struct AuthInterceptorTests {
     ])
     func test_redirect_web_signin_to_app(rawInput: String) async throws {
         let input = try #require(URL(string: rawInput))
-        let interceptor = await AuthenticationNavigator.Interceptor(hostProvider: hostProvider)
-        let output = await interceptor.filterSignInRedirect(input)
+        let interceptor = AuthenticationNavigator.Interceptor(hostProvider: hostProvider)
+        let output = interceptor.filterSignInRedirect(input)
         try #require(output != nil)
         #expect(output == WKNavigationActionPolicy.cancel)
     }
@@ -43,8 +44,8 @@ struct AuthInterceptorTests {
     ])
     func test_redirect_web_signing_irrelevant_url(rawInput: String) async throws {
         let input = try #require(URL(string: rawInput))
-        let interceptor = await AuthenticationNavigator.Interceptor(hostProvider: hostProvider)
-        let output = await interceptor.filterSignInRedirect(input)
+        let interceptor = AuthenticationNavigator.Interceptor(hostProvider: hostProvider)
+        let output = interceptor.filterSignInRedirect(input)
         try #require(output == nil)
     }
 
@@ -54,14 +55,14 @@ struct AuthInterceptorTests {
     @Test(arguments: ["bikeindex://?code=edf1d0dec505adfd97e89ad2b76c2e71"])
     func test_webview_redirect(rawInput: String) async throws {
         let input = try #require(URL(string: rawInput))
-        let interceptor = await AuthenticationNavigator.Interceptor(hostProvider: hostProvider)
-        let mockClient = try await #require(try MockClient())
+        let interceptor = AuthenticationNavigator.Interceptor(hostProvider: hostProvider)
+        let mockClient = try #require(try MockClient())
         let output = await interceptor.filterCompletedAuthentication(
             input,
             client: mockClient)
         try #require(output != nil)
         #expect(output == WKNavigationActionPolicy.cancel)
-        let accessToken = try #require(await mockClient.accessToken)
+        let accessToken = try #require(mockClient.accessToken)
         #expect(accessToken == rawInput.split(separator: "=")[1])
     }
 
@@ -71,8 +72,8 @@ struct AuthInterceptorTests {
     ])
     func test_webview_redirect_non_intercepted(rawInput: String) async throws {
         let input = try #require(URL(string: rawInput))
-        let interceptor = await AuthenticationNavigator.Interceptor(hostProvider: hostProvider)
-        let mockClient = try await #require(try Client())
+        let interceptor = AuthenticationNavigator.Interceptor(hostProvider: hostProvider)
+        let mockClient = try #require(try Client())
         let output = await interceptor.filterCompletedAuthentication(
             input,
             client: mockClient)

--- a/UnitTests/ScannedBikeModelTests.swift
+++ b/UnitTests/ScannedBikeModelTests.swift
@@ -11,28 +11,53 @@ import SwiftData
 @testable import BikeIndex
 
 @MainActor
-struct ScannedBikeModelTests {
+class ScannedBikeModelTests {
 
     @Test func test_handleDeeplink_once() async throws {
         let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
-        let container = try ModelContainer(
+        let container = try! ModelContainer(
             for: ScannedBike.self,
             configurations: config
         )
         let context = container.mainContext
+        let model = ScannedBikesViewModel(context: context,
+                                          client: try! Client())
+        do {
+            let fetch = FetchDescriptor(predicate: #Predicate<ScannedBike> { _ in true })
+            let beginningState = try context.fetchCount(fetch)
+            #expect(beginningState == 0)
 
+            let stickerUrl1 = URL(string: "https://bikeindex.org/bikes/scanned/A40340")!
+
+            model.handleDeeplink(stickerUrl1)
+
+            let endState = try! context.fetchCount(FetchDescriptor<ScannedBike>())
+            #expect(endState == 1)
+        } catch {
+            print("Hit error \(error)")
+        }
+    }
+
+    @Test func test_handleTwentyDeeplinks_expect10MostRecentOnly() async throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
+        let container = try! ModelContainer(
+            for: ScannedBike.self,
+            configurations: config
+        )
+        let context = container.mainContext
         let model = ScannedBikesViewModel(context: context,
                                           client: try! Client())
 
-        let beginningState = try! context.fetchCount(FetchDescriptor<ScannedBike>())
+        let fetch = FetchDescriptor(predicate: #Predicate<ScannedBike> { _ in true })
+        let beginningState = try context.fetchCount(fetch)
         #expect(beginningState == 0)
 
-        let stickerUrl1 = URL(string: "https://bikeindex.org/bikes/scanned/A40340")!
-
-        model.handleDeeplink(stickerUrl1)
+        (0..<20).forEach { _ in
+            let stickerUrl1 = URL(string: "https://bikeindex.org/bikes/scanned/A40340")!
+            model.handleDeeplink(stickerUrl1)
+        }
 
         let endState = try! context.fetchCount(FetchDescriptor<ScannedBike>())
-        #expect(endState == 1)
+        #expect(endState == 10)
     }
-
 }

--- a/UnitTests/ScannedBikeModelTests.swift
+++ b/UnitTests/ScannedBikeModelTests.swift
@@ -6,8 +6,9 @@
 //
 
 import Foundation
-import Testing
 import SwiftData
+import Testing
+
 @testable import BikeIndex
 
 @MainActor
@@ -35,7 +36,8 @@ class ScannedBikeModelTests {
             let dates = testSamples.map(\.createdAt.timeIntervalSince1970.description)
             let firstDate = dates.first ?? ""
             let lastDate = dates.last ?? ""
-            return "\(numberOfStickers).\(firstId)_\(lastId).\(firstId)_\(lastDate).\(expectedNumberOfStickers)"
+            return
+                "\(numberOfStickers).\(firstId)_\(lastId).\(firstId)_\(lastDate).\(expectedNumberOfStickers)"
         }
     }
 
@@ -47,28 +49,35 @@ class ScannedBikeModelTests {
         Input(numberOfStickers: 1, genesisBase: Date(), expectedNumberOfStickers: 1),
         Input(numberOfStickers: 10, genesisBase: Date()),
         Input(numberOfStickers: 5, genesisBase: Date(), expectedNumberOfStickers: 5),
-        Input(numberOfStickers: 10, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 21), expectedNumberOfStickers: 0),
+        Input(
+            numberOfStickers: 10, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 21),
+            expectedNumberOfStickers: 0),
         Input(numberOfStickers: 10, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 13)),
         Input(numberOfStickers: 20, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 14 + 1)),
-        Input(numberOfStickers: 20, genesisBase: Date())
+        Input(numberOfStickers: 20, genesisBase: Date()),
     ])
     func test_handleStickerDeeplinks(input: Input) async throws {
         let invocationName = input.invocationName
-        let config = ModelConfiguration(invocationName, isStoredInMemoryOnly: true, allowsSave: true)
+        let config = ModelConfiguration(
+            invocationName, isStoredInMemoryOnly: true, allowsSave: true)
         let container = try! ModelContainer(
             for: ScannedBike.self,
             configurations: config
         )
         let context = container.mainContext
         context.autosaveEnabled = false
-        let model = ScannedBikesViewModel(context: context,
-                                          client: try! Client())
+        let model = ScannedBikesViewModel(
+            context: context,
+            client: try! Client())
 
         let fetch = FetchDescriptor(predicate: #Predicate<ScannedBike> { _ in true })
         let beginningState = try context.fetchCount(fetch)
         #expect(beginningState == 0)
 
-        #expect(context.hasChanges == false, "\(type(of: self)) should not have pending changes before reaching body of test function \(#function)")
+        #expect(
+            context.hasChanges == false,
+            "\(type(of: self)) should not have pending changes before reaching body of test function \(#function)"
+        )
 
         do {
             try input.testSamples.forEach { sticker in
@@ -78,7 +87,10 @@ class ScannedBikeModelTests {
             #expect(false, "unexpected error \(error)")
         }
 
-        #expect(context.hasChanges == false, "\(type(of: self)) should not have pending changes before reaching body of test function \(#function)")
+        #expect(
+            context.hasChanges == false,
+            "\(type(of: self)) should not have pending changes before reaching body of test function \(#function)"
+        )
         let endState = try! context.fetchCount(FetchDescriptor<ScannedBike>())
         #expect(endState == input.expectedNumberOfStickers)
     }

--- a/UnitTests/ScannedBikeModelTests.swift
+++ b/UnitTests/ScannedBikeModelTests.swift
@@ -35,6 +35,10 @@ class ScannedBikeModelTests {
         }
     }
 
+    /// ``ScannedBikesViewModel`` must only persists the:
+    /// 1. Ten (10) most recent stickers
+    /// 2. Stickers created within the last two weeks.
+    /// All scanned bike stickers older, or in greater quantity, must be forgotten.
     @Test(arguments: [
         Input(numberOfStickers: 1, genesisBase: Date(), expectedNumberOfStickers: 1),
         Input(numberOfStickers: 10, genesisBase: Date()),

--- a/UnitTests/ScannedBikeModelTests.swift
+++ b/UnitTests/ScannedBikeModelTests.swift
@@ -1,0 +1,38 @@
+//
+//  ScannedBikeModelTests.swift
+//  UnitTests
+//
+//  Created by Jack on 5/11/25.
+//
+
+import Foundation
+import Testing
+import SwiftData
+@testable import BikeIndex
+
+@MainActor
+struct ScannedBikeModelTests {
+
+    @Test func test_handleDeeplink_once() async throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
+        let container = try ModelContainer(
+            for: ScannedBike.self,
+            configurations: config
+        )
+        let context = container.mainContext
+
+        let model = ScannedBikesViewModel(context: context,
+                                          client: try! Client())
+
+        let beginningState = try! context.fetchCount(FetchDescriptor<ScannedBike>())
+        #expect(beginningState == 0)
+
+        let stickerUrl1 = URL(string: "https://bikeindex.org/bikes/scanned/A40340")!
+
+        model.handleDeeplink(stickerUrl1)
+
+        let endState = try! context.fetchCount(FetchDescriptor<ScannedBike>())
+        #expect(endState == 1)
+    }
+
+}

--- a/UnitTests/ScannedBikeModelTests.swift
+++ b/UnitTests/ScannedBikeModelTests.swift
@@ -30,8 +30,12 @@ class ScannedBikeModelTests {
 
         var invocationName: String {
             let ids = testSamples.map(\.sticker).joined(separator: "_")
-            let dates = testSamples.map(\.createdAt.timeIntervalSince1970.description).joined(separator: "_")
-            return "\(numberOfStickers).\(ids)_\(dates).\(expectedNumberOfStickers)"
+            let firstId = ids.first ?? "0"
+            let lastId = ids.last ?? "0"
+            let dates = testSamples.map(\.createdAt.timeIntervalSince1970.description)
+            let firstDate = dates.first ?? ""
+            let lastDate = dates.last ?? ""
+            return "\(numberOfStickers).\(firstId)_\(lastId).\(firstId)_\(lastDate).\(expectedNumberOfStickers)"
         }
     }
 

--- a/UnitTests/ScannedBikeModelTests.swift
+++ b/UnitTests/ScannedBikeModelTests.swift
@@ -27,6 +27,12 @@ class ScannedBikeModelTests {
             }
             self.expectedNumberOfStickers = expectedNumberOfStickers
         }
+
+        var invocationName: String {
+            let ids = testSamples.map(\.sticker).joined(separator: "_")
+            let dates = testSamples.map(\.createdAt.timeIntervalSince1970.description).joined(separator: "_")
+            return "\(numberOfStickers).\(ids)_\(dates).\(expectedNumberOfStickers)"
+        }
     }
 
     @Test(arguments: [
@@ -39,7 +45,8 @@ class ScannedBikeModelTests {
         Input(numberOfStickers: 20, genesisBase: Date())
     ])
     func test_handleStickerDeeplinks(input: Input) async throws {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true, allowsSave: true)
+        let invocationName = input.invocationName
+        let config = ModelConfiguration(invocationName, isStoredInMemoryOnly: true, allowsSave: true)
         let container = try! ModelContainer(
             for: ScannedBike.self,
             configurations: config
@@ -57,7 +64,7 @@ class ScannedBikeModelTests {
 
         do {
             try input.testSamples.forEach { sticker in
-                try model.handleDeeplink(sticker.url)
+                try model.persist(sticker: sticker)
             }
         } catch {
             #expect(false, "unexpected error \(error)")

--- a/UnitTests/ScannedBikeModelTests.swift
+++ b/UnitTests/ScannedBikeModelTests.swift
@@ -20,6 +20,7 @@ class ScannedBikeModelTests {
             configurations: config
         )
         let context = container.mainContext
+        context.autosaveEnabled = false
         let model = ScannedBikesViewModel(context: context,
                                           client: try! Client())
         do {
@@ -29,7 +30,7 @@ class ScannedBikeModelTests {
 
             let stickerUrl1 = URL(string: "https://bikeindex.org/bikes/scanned/A40340")!
 
-            model.handleDeeplink(stickerUrl1)
+            try model.handleDeeplink(stickerUrl1)
 
             let endState = try! context.fetchCount(FetchDescriptor<ScannedBike>())
             #expect(endState == 1)
@@ -45,6 +46,7 @@ class ScannedBikeModelTests {
             configurations: config
         )
         let context = container.mainContext
+        context.autosaveEnabled = false
         let model = ScannedBikesViewModel(context: context,
                                           client: try! Client())
 
@@ -52,11 +54,14 @@ class ScannedBikeModelTests {
         let beginningState = try context.fetchCount(fetch)
         #expect(beginningState == 0)
 
+        #expect(context.hasChanges == false, "\(type(of: self)) should not have pending changes before reaching body of test function \(#function)")
+
         (0..<20).forEach { _ in
             let stickerUrl1 = URL(string: "https://bikeindex.org/bikes/scanned/A40340")!
-            model.handleDeeplink(stickerUrl1)
+            try! model.handleDeeplink(stickerUrl1)
         }
 
+        #expect(context.hasChanges == false, "\(type(of: self)) should not have pending changes before reaching body of test function \(#function)")
         let endState = try! context.fetchCount(FetchDescriptor<ScannedBike>())
         #expect(endState == 10)
     }

--- a/UnitTests/ScannedBikeModelTests.swift
+++ b/UnitTests/ScannedBikeModelTests.swift
@@ -12,28 +12,49 @@ import Testing
 @testable import BikeIndex
 
 @MainActor
-class ScannedBikeModelTests {
+struct ScannedBikeModelTests {
 
-    struct Input {
+    struct Input: CustomTestArgumentEncodable {
         let numberOfStickers: Int
-        let testSamples: [ScannedBike]
+        let testSamples: [(URL, Date)]
         let expectedNumberOfStickers: Int
+
+        var scannedBikesHistory: [ScannedBike] {
+            testSamples.map { (url, createdAt) in
+                let sticker = url.lastPathComponent
+                return ScannedBike(sticker: sticker, url: url, createdAt: createdAt)
+            }
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case numberOfStickers
+            case testSamples
+            case expectedNumberOfStickers
+        }
 
         init(numberOfStickers: Int = 20, genesisBase: Date, expectedNumberOfStickers: Int = 10) {
             self.numberOfStickers = numberOfStickers
             self.testSamples = (0..<numberOfStickers).map { index in
                 let url = URL(string: "https://bikeindex.org/bikes/scanned/\(index)")!
-                let createdAt = genesisBase.addingTimeInterval(-TimeInterval(index))
-                return ScannedBike(sticker: String(index), url: url, createdAt: createdAt)
+                let createdAt = genesisBase.addingTimeInterval(-TimeInterval(index * 60))
+                return (url, createdAt)
             }
             self.expectedNumberOfStickers = expectedNumberOfStickers
         }
 
+        func encodeTestArgument(to encoder: some Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(numberOfStickers, forKey: .numberOfStickers)
+            let testData = testSamples.map { "\($0)-\($1)" }
+            try container.encode(testData, forKey: .testSamples)
+            try container.encode(expectedNumberOfStickers, forKey: .expectedNumberOfStickers)
+        }
+
         var invocationName: String {
-            let ids = testSamples.map(\.sticker).joined(separator: "_")
+            let ids = scannedBikesHistory.map(\.sticker).joined(separator: "_")
             let firstId = ids.first ?? "0"
             let lastId = ids.last ?? "0"
-            let dates = testSamples.map(\.createdAt.timeIntervalSince1970.description)
+            let dates = scannedBikesHistory.map(\.createdAt.timeIntervalSince1970.description)
             let firstDate = dates.first ?? ""
             let lastDate = dates.last ?? ""
             return
@@ -45,17 +66,21 @@ class ScannedBikeModelTests {
     /// 1. Ten (10) most recent stickers
     /// 2. Stickers created within the last two weeks.
     /// All scanned bike stickers older, or in greater quantity, must be forgotten.
-    @Test(arguments: [
-        Input(numberOfStickers: 1, genesisBase: Date(), expectedNumberOfStickers: 1),
-        Input(numberOfStickers: 10, genesisBase: Date()),
-        Input(numberOfStickers: 5, genesisBase: Date(), expectedNumberOfStickers: 5),
-        Input(
-            numberOfStickers: 10, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 21),
-            expectedNumberOfStickers: 0),
-        Input(numberOfStickers: 10, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 13)),
-        Input(numberOfStickers: 20, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 14 + 1)),
-        Input(numberOfStickers: 20, genesisBase: Date()),
-    ])
+    @Test(
+        "Scanned Sticker History Data Layer",
+        arguments: [
+            Input(numberOfStickers: 1, genesisBase: Date(), expectedNumberOfStickers: 1),
+            Input(numberOfStickers: 10, genesisBase: Date()),
+            Input(numberOfStickers: 5, genesisBase: Date(), expectedNumberOfStickers: 5),
+            Input(
+                numberOfStickers: 10, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 21),
+                expectedNumberOfStickers: 0),
+            Input(numberOfStickers: 10, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 13)),
+            Input(
+                numberOfStickers: 20, genesisBase: Date().addingTimeInterval(-60 * 60 * 24 * 14 + 1)
+            ),
+            Input(numberOfStickers: 20, genesisBase: Date()),
+        ])
     func test_handleStickerDeeplinks(input: Input) async throws {
         let invocationName = input.invocationName
         let config = ModelConfiguration(
@@ -80,7 +105,7 @@ class ScannedBikeModelTests {
         )
 
         do {
-            try input.testSamples.forEach { sticker in
+            try input.scannedBikesHistory.forEach { sticker in
                 try model.persist(sticker: sticker)
             }
         } catch {


### PR DESCRIPTION
# Description

Part 1

- Add data layer for 10-most-recent bike stickers scanned in the last 2 weeks
- Change ScannedBike from struct to `@Model class`
- Add `ScannedBikesViewModel` to marshal models
- Change deeplink handling to
    1. Create only one `DeeplinkManager` instance (previously it would be destroyed and re-created on every scan).
    2. Change only the DeeplinkManager.scannedBike` field for a new scan.
- Move `ScannedBike` to its own file
- Add unit test to check both conditions of history window (10 items, within 2 weeks)

Separation of concerns:
- DeeplinkManager only keeps the latest ScannedBike QR sticker in memory
- ScannedBikesViewModel only writes the latest QR sticker (and purges any scans older than 2 weeks or past the 10-most-recent) to SwiftData

Part 2: pull request to add UI for sticker history to follow later