### PR TITLE
Feat: Add RecentlyScannedStickersView to display recent QR scans

### DIFF
--- a/BikeIndex/Model/Deeplinks/DeeplinkManager.swift
+++ b/BikeIndex/Model/Deeplinks/DeeplinkManager.swift
@@ -19,10 +19,10 @@ final class DeeplinkManager: Identifiable {
         self.hostProvider = host
     }
 
-    /// Every URL scan should go through this function
+    /// Every URL scan should go through this function.
+    /// However this does _not_ assign self.scannedBike, that will be done later.
     func scan(url: URL?) -> DeeplinkResult? {
         if let scannedBike = ScannedBike(host: hostProvider, url: url) {
-            self.scannedBike = scannedBike
             return DeeplinkResult(scannedBike: scannedBike)
         } else {
             return nil

--- a/BikeIndex/Model/Deeplinks/ScannedBike.swift
+++ b/BikeIndex/Model/Deeplinks/ScannedBike.swift
@@ -6,6 +6,8 @@
 //
 
 import Foundation
+import OSLog
+import RegexBuilder
 import SwiftData
 
 @Model
@@ -25,6 +27,62 @@ class ScannedBike: Equatable, Identifiable {
         self.sticker = sticker
         self.url = url
         self.createdAt = createdAt
+    }
+
+    // MARK: - Formatting and display
+
+    var displayTitle: String {
+        // NOTE: Avoid any truncation if sticker codes are longer than expected
+        guard sticker.trimmingCharacters(in: .whitespacesAndNewlines).count <= 9 else {
+            return sticker
+        }
+
+        do {
+            if let match = try ScannedBike.regex.ignoresCase(true).firstMatch(in: sticker) {
+                // First tuple item is the whole match
+                let (_, letterGroup, firstDigits, secondDigits) = match.output
+                return "\(letterGroup) \(firstDigits) \(secondDigits)"
+            } else {
+                return sticker
+            }
+        } catch {
+            Logger.model.error("Failed to parse sticker \(self.sticker, privacy: .public)")
+            return sticker
+        }
+
+    }
+
+    private static var regex: Regex<(Substring, String, Substring, String)> {
+        let letters: CharacterClass = .generalCategory(.lowercaseLetter)
+            .union(.generalCategory(.uppercaseLetter))
+
+        return Regex {
+            Anchor.startOfLine
+            Capture {
+                ZeroOrMore(letters)
+            } transform: {
+                let gap = max(0, 3 - $0.count)
+                let leftPad = String(repeating: " ", count: gap)
+                return leftPad + $0
+            }
+            ZeroOrMore(.whitespace)
+            Capture {
+                OneOrMore(.digit, .reluctant)
+                OneOrMore(.digit, .reluctant)
+                OneOrMore(.digit, .reluctant)
+            }
+            ZeroOrMore(.whitespace)
+            Capture {
+                OneOrMore(.digit, .reluctant)
+                ZeroOrMore(.digit, .reluctant)
+                ZeroOrMore(.digit, .reluctant)
+            } transform: {
+                $0.padding(toLength: 3, withPad: " ", startingAt: 0)
+            }
+
+            Anchor.endOfLine
+        }
+        .ignoresCase(true)
     }
 }
 

--- a/BikeIndex/View/Deeplinks/RecentlyScannedStickersView.swift
+++ b/BikeIndex/View/Deeplinks/RecentlyScannedStickersView.swift
@@ -1,0 +1,88 @@
+//
+//  RecentlyScannedStickersView.swift
+//  BikeIndex
+//
+//  Created by Jack on 5/11/25.
+//
+
+import SwiftData
+import SwiftUI
+
+struct RecentlyScannedStickersView: View {
+    @Query(sort: [SortDescriptor(\ScannedBike.createdAt, order: .reverse)])
+    var stickers: [ScannedBike]
+
+    @State var path = NavigationPath()
+
+    @Binding var display: Bool
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            // Duplicated/repeated scans are allowed but duplicates on ScannedBike.id cause problems for List
+            // so we need to de-duplicate List on persistentModelID
+            List(stickers, id: \.persistentModelID) { sticker in
+                NavigationLink {
+                    ScannedBikePage(viewModel: .init(scan: sticker, path: path, dismiss: nil))
+                        .interactiveDismissDisabled()
+                } label: {
+                    StickerDisplayLabel(sticker: sticker)
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle("Recently Scanned Stickers")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Close") {
+                        display = false
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    @Previewable let client = try! Client()
+
+    @Previewable let container = try! ModelContainer(
+        for: ScannedBike.self,
+        configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+
+    RecentlyScannedStickersView(display: .constant(true))
+        .environment(client)
+        .modelContainer(container)
+        .onAppear {
+            for identifier in ["SAM000000", "A40340", "NONMATCH"] {
+                if let sampleSticker = ScannedBike(
+                    host: client.hostProvider,
+                    url: URL(string: "https://bikeindex.org/bikes/scanned/\(identifier)"))
+                {
+                    container.mainContext.insert(sampleSticker)
+                }
+            }
+
+            try! container.mainContext.save()
+        }
+}
+
+struct StickerDisplayLabel: View {
+    var sticker: ScannedBike
+
+    var body: some View {
+        HStack {
+            Text(sticker.displayTitle)
+                .monospaced()
+                .bold()
+                .foregroundStyle(.white)
+                .background {
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .scale(1.15)
+                        .fill(.accent)
+                }
+                .padding(.leading, 2)
+
+            Spacer()
+            Text("\(sticker.createdAt, style: .relative)")
+        }
+    }
+}

--- a/BikeIndex/View/Deeplinks/ScannedBikePage.swift
+++ b/BikeIndex/View/Deeplinks/ScannedBikePage.swift
@@ -24,14 +24,18 @@ struct ScannedBikePage: View {
             .environment(client)
             .navigationTitle(viewModel.title)
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Close") {
-                        viewModel.dismiss()
+                if viewModel.dismiss != nil {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button("Close") {
+                            viewModel.dismiss?()
+                        }
                     }
                 }
             }
             .onAppear {
-                Logger.views.debug("ScannedBikePage opening sticker for \(viewModel.scan.url)")
+                Logger.views.debug(
+                    "ScannedBikePage opening sticker for \(viewModel.scan.url) -- \\(viewModel.scan.persistentModelID)"
+                )
             }
         }
     }
@@ -42,14 +46,15 @@ extension ScannedBikePage {
     final class ViewModel {
         var scan: ScannedBike
         var path: NavigationPath
-        var dismiss: () -> Void
+        var dismiss: (() -> Void)?
+        // TODO: onDisappear needs to be connected to NavigableWebView.navigator actions for /register URLs
         var onDisappear: MainContent?
 
         var title: String {
-            scan.sticker
+            scan.displayTitle
         }
 
-        init(scan: ScannedBike, path: NavigationPath, dismiss: @escaping () -> Void) {
+        init(scan: ScannedBike, path: NavigationPath, dismiss: (() -> Void)?) {
             self.scan = scan
             self.path = path
             self.dismiss = dismiss

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -75,8 +75,6 @@ struct MainContentPage: View {
             .sheet(
                 item: $deeplinkManager.scannedBike,
                 content: { scan in
-                    // Dismiss any previous stickers
-                    // self.viewModel.displayRecentlyScannedStickers = false
                     // Open the new sticker
                     let viewModel = ScannedBikePage.ViewModel(
                         scan: scan,

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -42,7 +42,8 @@ struct MainContentPage: View {
                     path: $viewModel.path,
                     loading: $viewModel.fetching,
                     groupMode: $viewModel.groupMode,
-                    sortOrder: $viewModel.sortOrder)
+                    sortOrder: $viewModel.sortOrder,
+                    displayRecentlyScannedStickers: $viewModel.displayRecentlyScannedStickers)
             }
             .navigationTitle("Bike Index")
             .navigationDestination(for: MainContent.self) { selection in
@@ -74,6 +75,9 @@ struct MainContentPage: View {
             .sheet(
                 item: $deeplinkManager.scannedBike,
                 content: { scan in
+                    // Dismiss any previous stickers
+                    // self.viewModel.displayRecentlyScannedStickers = false
+                    // Open the new sticker
                     let viewModel = ScannedBikePage.ViewModel(
                         scan: scan,
                         path: viewModel.path,
@@ -86,6 +90,12 @@ struct MainContentPage: View {
                                 viewModel.path.append(exitPath)
                             }
                         }
+                }
+            )
+            .fullScreenCover(
+                isPresented: $viewModel.displayRecentlyScannedStickers,
+                content: {
+                    RecentlyScannedStickersView(display: $viewModel.displayRecentlyScannedStickers)
                 }
             )
             .alert(isPresented: $viewModel.showError, error: viewModel.lastError) {

--- a/BikeIndex/View/MainContent/MainToolbar.swift
+++ b/BikeIndex/View/MainContent/MainToolbar.swift
@@ -5,6 +5,7 @@
 //  Created by Jack on 12/31/23.
 //
 
+import SwiftData
 import SwiftUI
 
 extension MainContentPage {
@@ -15,6 +16,9 @@ extension MainContentPage {
         @Binding var loading: Bool
         @Binding var groupMode: ViewModel.GroupMode
         @Binding var sortOrder: SortOrder
+        @Binding var displayRecentlyScannedStickers: Bool
+
+        @Query var recentStickers: [ScannedBike]
 
         var body: some ToolbarContent {
             ToolbarItemGroup(placement: .topBarLeading) {
@@ -33,6 +37,21 @@ extension MainContentPage {
                     Label("Help", systemImage: "book.closed")
                 }
                 .accessibilityHint("Open frequently asked questions and help pages")
+            }
+
+            if recentStickers.isEmpty == false {
+                ToolbarItem(placement: .status) {
+                    Button {
+                        displayRecentlyScannedStickers = true
+                    } label: {
+                        Label(
+                            "\(recentStickers.count) Recently Scanned Stickers",
+                            systemImage: "qrcode"
+                        )
+                        .labelStyle(.titleAndIcon)
+                    }
+
+                }
             }
 
             ToolbarItemGroup(placement: .topBarTrailing) {
@@ -86,6 +105,7 @@ extension MainContentPage {
     @Previewable @State var path = NavigationPath()
     @Previewable @State var groupMode = MainContentPage.ViewModel.GroupMode.byStatus
     @Previewable @State var sortOrder: SortOrder = .forward
+    @Previewable @State var displayRecentlyScannedStickers = false
     NavigationStack {
         Text("Toolbar preview")
             .toolbar {
@@ -93,7 +113,8 @@ extension MainContentPage {
                     path: $path,
                     loading: .constant(true),
                     groupMode: $groupMode,
-                    sortOrder: $sortOrder)
+                    sortOrder: $sortOrder,
+                    displayRecentlyScannedStickers: $displayRecentlyScannedStickers)
             }
     }
     .environment(try! Client())

--- a/BikeIndex/ViewModel/MainContent/MainContent+ViewModel.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+ViewModel.swift
@@ -48,8 +48,11 @@ extension MainContentPage {
 
         // MARK: Child View State
 
-        // Control the navigation hierarchy for all views after this one
+        /// Control the navigation hierarchy for all views after this one
         var path = NavigationPath()
+
+        /// Present a sheet for Recently Scanned Stickers
+        var displayRecentlyScannedStickers: Bool = false
 
         // MARK: - Network Operations
 

--- a/BikeIndex/ViewModel/ScannedBikesViewModel.swift
+++ b/BikeIndex/ViewModel/ScannedBikesViewModel.swift
@@ -20,7 +20,7 @@ struct ScannedBikesViewModel {
         self.client = client
     }
 
-    func persist(sticker: ScannedBike) throws {
+    func persist(sticker: ScannedBike) throws -> ScannedBike {
         // 1. Save the latest scanned bike sticker
         context.insert(sticker)
         try context.save()
@@ -51,5 +51,7 @@ struct ScannedBikesViewModel {
             where: #Predicate<ScannedBike> { model in
                 tenMostRecentStickers.contains(model.persistentModelID) == false
             })
+
+        return sticker
     }
 }


### PR DESCRIPTION
# Description

- use a static regex to match the pretty sticker display that the website does
- if the regex fails, just a regular string will be displayed
- stylize the StickerDisplayLabel
- use the pretty grouped sticker title for web views
- works for guests and authenticated users
- display Recently Scanned Stickers _fullscreen_ for authenticated users, and in a sheet for guests

Scanned Bikes route through:
- BikeIndexApp deeplink closures to handleDeeplink
- to DeeplinkManager.scan
- to ScannedBike.persist
- back to DeeplinkManager.scannedBike property
- out to various Views that change on the state