### PR TITLE
Fix MainContentPage alert handler

### DIFF
--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -98,9 +98,8 @@ struct MainContentPage: View {
                 }
             )
              */
-            .alert(isPresented: $viewModel.showError, error: viewModel.lastError) {
-                Text("Okay")
-            }
+            // empty action block to rely on default Button("OK") behavior
+            .alert(isPresented: $viewModel.showError, error: viewModel.lastError) {}
             .onAppear {
                 Logger.views.debug(
                     "Starting main content page with deeplink scanned bike \(String(describing: deeplinkManager.scannedBike))"

--- a/BikeIndex/ViewModel/MainContent/MainContent+ViewModel.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+ViewModel.swift
@@ -23,13 +23,9 @@ extension MainContentPage {
         // Normal operation handling
         var fetching = true
         // Error Handling
-        public var lastError: ViewModel.Error? = nil
+        var lastError: ViewModel.Error? = nil
         // Alert presentation
-        var showError: Bool = false {
-            didSet {
-                if showError { fetching = false }
-            }
-        }
+        var showError: Bool = false
 
         // MARK: Query Management
 
@@ -79,6 +75,7 @@ extension MainContentPage {
                 Logger.model.error("Failed to user info: \(error)")
                 lastError = error
                 showError = true
+                fetching = false
             }
         }
 


### PR DESCRIPTION
# Description

- Previously, Text() was not actionable!
- Rely on default behavior of .alert(action: {}) with empty block
- See: https://developer.apple.com/documentation/swiftui/view/alert(ispresented:error:actions:message:)
- Remove computed properties on MainContentPage.ViewModel to ensure bindings work correctly

### Screenshots

| Previous behavior | Corrected behavior |
| -- | -- |
| ![Simulator Screenshot - iPhone 16 - 2025-06-11 at 23 11 00](https://github.com/user-attachments/assets/907f8386-0ba9-49da-b5c1-881e7b172e6b) | ![Simulator Screenshot - iPhone 16 - 2025-06-11 at 23 10 45](https://github.com/user-attachments/assets/af824008-088f-406e-a722-e33efc592261) |
