### PR TITLE
Switch to pull_request_target 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-.github/ @aokj4ck
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-
+.github/ @aokj4ck

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+.github/ @aokj4ck
+

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,6 +3,8 @@ name: iOS Test Suite
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   pull_request_target:
     branches: [ "main" ]
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,7 +3,7 @@ name: iOS Test Suite
 on:
   push:
     branches: [ "main" ]
-  pull_request:
+  pull_request_target:
     branches: [ "main" ]
 
 jobs:


### PR DESCRIPTION
# Description

- Change ios.yml `pull_request` to `pull_request_target`
- This should enable forks to run fairly safely alongside fair security settings
- Future optimization: revert to `pull_request` and change the CI jobs to run under `workflow_run` 

# References

- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#controlling-changes-from-forks-to-workflows-in-public-repositories
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
- https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/