### PR TITLE
CI: Remove branch specifier from pull_request_target trigger

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,6 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Print git checkout status
+        ref: ${{ github.base_ref }}
         run: |
           git rev-parse --abbrev-ref HEAD
           git rev-parse HEAD

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,8 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Print git checkout status
         ref: ${{ github.ref }}
+      - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD
           git rev-parse HEAD
@@ -53,6 +53,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        ref: ${{ github.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -93,6 +94,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        ref: ${{ github.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request_target:
-    branches: [ "main" ]
 
 jobs:
   tests_iphone16:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Print git checkout status
-        ref: ${{ github.base_ref }}
+        ref: ${{ github.ref }}
         run: |
           git rev-parse --abbrev-ref HEAD
           git rev-parse HEAD


### PR DESCRIPTION
# Description

- Pull requests from forks are _not_ running on the new branch
- They're just running on `main`
    - see example PR run https://github.com/bikeindex/bike_index_ios/actions/runs/15938274260/job/44962319474?pr=85 > "Print git checkout status" 
    - which matched `main` commit 426664c554369d75d6707ea2ece51a2b0013fb5f
- Remove `branches: [ "main" ]` from ios.yml
- Add `ref: ${{ github.ref }}` to Checkout step (`actions/checkout@v4`)
- Specification for .github/workflows > on: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions\#on