### PR TITLE
CI: Add explicit permissions for GHA GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,5 +1,5 @@
 name: iOS Test Suite
-permissions: {}
+permissions: read
 
 on:
   push:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        ref: ${{ github.ref }}
+        with:
+          ref: ${{ github.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -54,7 +55,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        ref: ${{ github.ref }}
+        with:
+          ref: ${{ github.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -95,7 +97,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        ref: ${{ github.ref }}
+        with:
+          ref: ${{ github.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,5 +1,6 @@
 name: iOS Test Suite
-permissions: read
+permissions:
+  contents: read
 
 on:
   push:
@@ -14,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -56,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -98,7 +99,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.ref }}
+          ref: ${{ github.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.ref }}
+          ref: ${{ github.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.ref }}
+          ref: ${{ github.ref }}
       - name: Print git checkout status
         run: |
           git rev-parse --abbrev-ref HEAD

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,5 @@
 name: iOS Test Suite
+permissions: {}
 
 on:
   push:


### PR DESCRIPTION
# Description

- Fix code scanning alerts ([alert 1](https://github.com/bikeindex/bike_index_ios/security/code-scanning/1),[ alert 2](https://github.com/bikeindex/bike_index_ios/security/code-scanning/2), [alert 3](https://github.com/bikeindex/bike_index_ios/security/code-scanning/3)) that warn of implicit workflow permissions
- https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token