### PR TITLE
CI: Tryfix distinguish github context values

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -20,116 +20,12 @@ jobs:
         run: |
           git rev-parse --abbrev-ref HEAD
           git rev-parse HEAD
-      - name: Set Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
-      - name: Install tools
-        run: |
-          brew install rbenv
-          brew install ruby-build
-          brew install gh
-          bundler install
-      - name: Set up xcconfig secrets (see README.md#quick-start)
-        env:
-          BIKE_INDEX_DEVELOPMENT_XCCONFIG: ${{ secrets.BIKE_INDEX_DEVELOPMENT_XCCONFIG }}
-        run: |
-          echo "$BIKE_INDEX_DEVELOPMENT_XCCONFIG" >> BikeIndex-development.xcconfig
-      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
-        env:
-          BIKE_INDEX_TEST_CREDENTIALS: ${{ secrets.BIKE_INDEX_TEST_CREDENTIALS }}
-        run: |
-          echo "$BIKE_INDEX_TEST_CREDENTIALS" >> Test-credentials.xcconfig
-      - name: List available simulators
-        run: xcodebuild -scheme Debug\ \(development\) -project BikeIndex.xcodeproj -showdestinations
-      - name: Run tests
-        id: fastlane-ios-tests
-        run: bundle exec fastlane ios tests_iphone16
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test_output_iphone16
-          path: "fastlane/test_output/*"
-          compression-level: 9 # maximum compression
-
-  tests_iphone16plus:
-    name: Run iPhone 16 Plus test suite with fastlane
-    runs-on: macos-15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-      - name: Print git checkout status
-        run: |
-          git rev-parse --abbrev-ref HEAD
-          git rev-parse HEAD
-      - name: Set Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
-      - name: Install tools
-        run: |
-          brew install rbenv
-          brew install ruby-build
-          brew install gh
-          bundler install
-      - name: Set up xcconfig secrets (see README.md#quick-start)
-        env:
-          BIKE_INDEX_DEVELOPMENT_XCCONFIG: ${{ secrets.BIKE_INDEX_DEVELOPMENT_XCCONFIG }}
-        run: |
-          echo "$BIKE_INDEX_DEVELOPMENT_XCCONFIG" >> BikeIndex-development.xcconfig
-      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
-        env:
-          BIKE_INDEX_TEST_CREDENTIALS: ${{ secrets.BIKE_INDEX_TEST_CREDENTIALS }}
-        run: |
-          echo "$BIKE_INDEX_TEST_CREDENTIALS" >> Test-credentials.xcconfig
-      - name: List available simulators
-        run: xcodebuild -scheme Debug\ \(development\) -project BikeIndex.xcodeproj -showdestinations
-      - name: Run tests
-        id: fastlane-ios-tests
-        run: bundle exec fastlane ios tests_iphone16plus
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test_output_iphone16plus
-          path: "fastlane/test_output/*"
-          compression-level: 9 # maximum compression
-
-  tests_ipad:
-    name: Run iPad (10th generation) test suite with fastlane
-    runs-on: macos-15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-      - name: Print git checkout status
-        run: |
-          git rev-parse --abbrev-ref HEAD
-          git rev-parse HEAD
-      - name: Set Xcode 16.4
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
-      - name: Install tools
-        run: |
-          brew install rbenv
-          brew install ruby-build
-          brew install gh
-          bundler install
-      - name: Set up xcconfig secrets (see README.md#quick-start)
-        env:
-          BIKE_INDEX_DEVELOPMENT_XCCONFIG: ${{ secrets.BIKE_INDEX_DEVELOPMENT_XCCONFIG }}
-        run: |
-          echo "$BIKE_INDEX_DEVELOPMENT_XCCONFIG" >> BikeIndex-development.xcconfig
-      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
-        env:
-          BIKE_INDEX_TEST_CREDENTIALS: ${{ secrets.BIKE_INDEX_TEST_CREDENTIALS }}
-        run: |
-          echo "$BIKE_INDEX_TEST_CREDENTIALS" >> Test-credentials.xcconfig
-      - name: List available simulators
-        run: xcodebuild -scheme Debug\ \(development\) -project BikeIndex.xcodeproj -showdestinations
-      - name: Run tests
-        id: fastlane-ios-tests
-        run: bundle exec fastlane ios tests_ipad
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test_output_ipad
-          path: "fastlane/test_output/*"
-          compression-level: 9 # maximum compression
+          echo plain ref ${{ github.ref }}
+          echo trigger sha ${{ github.sha }}
+          echo ref name ${{ github.ref_name }}
+          echo protected ${{ github.ref_protected }}
+          echo base ref ${{ github.base_ref }}
+          echo head ref ${{ github.head_ref }}
+          echo event ${{ github.event }}
+          echo workflow_ref ${{ github.workflow_ref }}
+          echo workflow_sha ${{ github.workflow_sha }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -29,3 +29,134 @@ jobs:
           echo event ${{ github.event }}
           echo workflow_ref ${{ github.workflow_ref }}
           echo workflow_sha ${{ github.workflow_sha }}
+      - name: Set Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+      - name: Install tools
+        run: |
+          brew install rbenv
+          brew install ruby-build
+          brew install gh
+          bundler install
+      - name: Set up xcconfig secrets (see README.md#quick-start)
+        env:
+          BIKE_INDEX_DEVELOPMENT_XCCONFIG: ${{ secrets.BIKE_INDEX_DEVELOPMENT_XCCONFIG }}
+        run: |
+          echo "$BIKE_INDEX_DEVELOPMENT_XCCONFIG" >> BikeIndex-development.xcconfig
+      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
+        env:
+          BIKE_INDEX_TEST_CREDENTIALS: ${{ secrets.BIKE_INDEX_TEST_CREDENTIALS }}
+        run: |
+          echo "$BIKE_INDEX_TEST_CREDENTIALS" >> Test-credentials.xcconfig
+      - name: List available simulators
+        run: xcodebuild -scheme Debug\ \(development\) -project BikeIndex.xcodeproj -showdestinations
+      - name: Run tests
+        id: fastlane-ios-tests
+        run: bundle exec fastlane ios tests_iphone16
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test_output_iphone16
+          path: "fastlane/test_output/*"
+          compression-level: 9 # maximum compression
+
+  tests_iphone16plus:
+    name: Run iPhone 16 Plus test suite with fastlane
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Print git checkout status
+        run: |
+          git rev-parse --abbrev-ref HEAD
+          git rev-parse HEAD
+          echo plain ref ${{ github.ref }}
+          echo trigger sha ${{ github.sha }}
+          echo ref name ${{ github.ref_name }}
+          echo protected ${{ github.ref_protected }}
+          echo base ref ${{ github.base_ref }}
+          echo head ref ${{ github.head_ref }}
+          echo event ${{ github.event }}
+          echo workflow_ref ${{ github.workflow_ref }}
+          echo workflow_sha ${{ github.workflow_sha }}
+      - name: Set Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+      - name: Install tools
+        run: |
+          brew install rbenv
+          brew install ruby-build
+          brew install gh
+          bundler install
+      - name: Set up xcconfig secrets (see README.md#quick-start)
+        env:
+          BIKE_INDEX_DEVELOPMENT_XCCONFIG: ${{ secrets.BIKE_INDEX_DEVELOPMENT_XCCONFIG }}
+        run: |
+          echo "$BIKE_INDEX_DEVELOPMENT_XCCONFIG" >> BikeIndex-development.xcconfig
+      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
+        env:
+          BIKE_INDEX_TEST_CREDENTIALS: ${{ secrets.BIKE_INDEX_TEST_CREDENTIALS }}
+        run: |
+          echo "$BIKE_INDEX_TEST_CREDENTIALS" >> Test-credentials.xcconfig
+      - name: List available simulators
+        run: xcodebuild -scheme Debug\ \(development\) -project BikeIndex.xcodeproj -showdestinations
+      - name: Run tests
+        id: fastlane-ios-tests
+        run: bundle exec fastlane ios tests_iphone16plus
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test_output_iphone16plus
+          path: "fastlane/test_output/*"
+          compression-level: 9 # maximum compression
+
+  tests_ipad:
+    name: Run iPad (10th generation) test suite with fastlane
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+      - name: Print git checkout status
+        run: |
+          git rev-parse --abbrev-ref HEAD
+          git rev-parse HEAD
+          echo plain ref ${{ github.ref }}
+          echo trigger sha ${{ github.sha }}
+          echo ref name ${{ github.ref_name }}
+          echo protected ${{ github.ref_protected }}
+          echo base ref ${{ github.base_ref }}
+          echo head ref ${{ github.head_ref }}
+          echo event ${{ github.event }}
+          echo workflow_ref ${{ github.workflow_ref }}
+          echo workflow_sha ${{ github.workflow_sha }}
+      - name: Set Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+      - name: Install tools
+        run: |
+          brew install rbenv
+          brew install ruby-build
+          brew install gh
+          bundler install
+      - name: Set up xcconfig secrets (see README.md#quick-start)
+        env:
+          BIKE_INDEX_DEVELOPMENT_XCCONFIG: ${{ secrets.BIKE_INDEX_DEVELOPMENT_XCCONFIG }}
+        run: |
+          echo "$BIKE_INDEX_DEVELOPMENT_XCCONFIG" >> BikeIndex-development.xcconfig
+      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
+        env:
+          BIKE_INDEX_TEST_CREDENTIALS: ${{ secrets.BIKE_INDEX_TEST_CREDENTIALS }}
+        run: |
+          echo "$BIKE_INDEX_TEST_CREDENTIALS" >> Test-credentials.xcconfig
+      - name: List available simulators
+        run: xcodebuild -scheme Debug\ \(development\) -project BikeIndex.xcodeproj -showdestinations
+      - name: Run tests
+        id: fastlane-ios-tests
+        run: bundle exec fastlane ios tests_ipad
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test_output_ipad
+          path: "fastlane/test_output/*"
+          compression-level: 9 # maximum compression


### PR DESCRIPTION
# Description

- Actual behavior: PRs run CI on a `main` checkout
- Expected behavior: PRs run CI on _the contents of the PR branch to validate the changes_