### PR TITLE
CI: Remove pull_request_target

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-  pull_request_target:
 
 jobs:
   tests_iphone16:


### PR DESCRIPTION
# Description

- Seems like pull_request runs correctly for PRs inside the repo
- based on this run: https://github.com/bikeindex/bike_index_ios/actions/runs/15947623925/job/44983633871
- from #94 > ci/debug-pr-checkout-2 > pull_request > iPad run
- Seeking other approaches for pull_request_target from PR branches (maybe workflow_run will help)
- This should leave the repo CI in a stable state, with debug info, until we can dig in to adjust the next fork-based PR