### PR TITLE
Tests: Adopt Robot pattern for BikeIndexUITests

### DIFF
--- a/UITests/AuthenticatedUITestCase.swift
+++ b/UITests/AuthenticatedUITestCase.swift
@@ -12,7 +12,7 @@ import XCTest
 extension XCTestCase {
     @MainActor
     func signIn(app: XCUIApplication) throws {
-        try Robot(app: app, testCase: self).signIn()
+        try Robot(app).signIn()
     }
 
 }

--- a/UITests/BikeDetailRobot.swift
+++ b/UITests/BikeDetailRobot.swift
@@ -1,0 +1,17 @@
+//
+//  BikeDetailRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/2/25.
+//
+
+final class BikeDetailRobot: Robot {
+    lazy var editButton = app.buttons["Edit"]
+
+    @discardableResult
+    func tapEditButton() -> EditBikeRobot {
+        tap(editButton)
+
+        return EditBikeRobot(app)
+    }
+}

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -10,9 +10,7 @@ import XCTest
 
 @MainActor
 final class BikeIndexUITests: XCTestCase {
-    let timeout: TimeInterval = 60
     let app = XCUIApplication()
-    lazy var backButton = app.navigationBars.buttons.element(boundBy: 0)
 
     override func setUpWithError() throws {
         continueAfterFailure = false
@@ -123,7 +121,9 @@ final class BikeIndexUITests: XCTestCase {
             .tapSettings()
 
             .tapUserSettings()
-            .checkTextExists("Give us permission to contact you if we believe your bike has been stolen,")
+            .checkTextExists(
+                "Give us permission to contact you if we believe your bike has been stolen,"
+            )
             .back()
 
             .tapPassword()
@@ -137,29 +137,6 @@ final class BikeIndexUITests: XCTestCase {
             .tapRegistrationOrganization()
             .checkTextExists("Manage the organizations your bikes are registered with.")
             .back()
-    }
-
-    // MARK: - Helpers
-
-    func back() {
-        _ = backButton.waitForExistence(timeout: timeout)
-        backButton.tap()
-    }
-
-    func link(with prefix: String) -> XCUIElement {
-        app.links.matching(NSPredicate(format: "label BEGINSWITH %@", prefix)).element
-    }
-
-    func openSettings() {
-        let settings = app.buttons["Settings"]
-        _ = settings.waitForExistence(timeout: timeout)
-        settings.tap()
-    }
-
-    func button(named: String) -> XCUIElement {
-        let button = app.buttons[named]
-        _ = button.waitForExistence(timeout: timeout)
-        return button
     }
 }
 

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -169,23 +169,16 @@ extension BikeIndexUITests {
     /// to test through the `BikeIndex/AuthView` flow. This omission is passable for this
     /// test because MainContentPage has the same button. But it may need an answer later.
     func testUnauthenticatedHelp() throws {
-        app.launch()
-
-        let unauthenticatedHelpButton = app.buttons["Help"]
-        _ = unauthenticatedHelpButton.waitForExistence(timeout: timeout)
-        unauthenticatedHelpButton.tap()
-
-        back()
+        MainContentRobot(app)
+            .start()
+            .tapHelpButton()
+            .back()
     }
 
     func testMainContentPageHelp() throws {
-        app.launch()
-        try signIn(app: app)
-
-        let unauthenticatedHelpButton = app.buttons["Help"]
-        _ = unauthenticatedHelpButton.waitForExistence(timeout: timeout)
-        unauthenticatedHelpButton.tap()
-
-        back()
+        try MainContentRobot(app)
+            .startWithSignIn()
+            .tapHelpButton()
+            .back()
     }
 }

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -123,7 +123,7 @@ final class BikeIndexUITests: XCTestCase {
             .tapSettings()
 
             .tapUserSettings()
-            .checkTextExists("Give us permission to contact you if we believe your bike has been stolen, even if it isn't marked stolen")
+            .checkTextExists("Give us permission to contact you if we believe your bike has been stolen,")
             .back()
 
             .tapPassword()

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -34,7 +34,7 @@ final class BikeIndexUITests: XCTestCase {
 
     /// Sometimes this fails when a page plainly fails to load, may need to add more resiliency.
     func test_basic_bike_detail_navigation() throws {
-        try Robot(app)
+        try MainContentRobot(app)
             .startWithSignIn()
             .tapFirstBike()
             .tapEditButton()
@@ -44,51 +44,23 @@ final class BikeIndexUITests: XCTestCase {
     }
 
     func test_basic_settings_navigation() throws {
-        app.launch()
-        try signIn(app: app)
-
-        openSettings()
-
-        let appIcon = app.buttons["App Icon"]
-        _ = appIcon.waitForExistence(timeout: timeout)
-        appIcon.tap()
-
-        back()
-
-        let debugMenu = app.buttons["Debug menu"]
-        _ = debugMenu.waitForExistence(timeout: timeout)
-        debugMenu.tap()
-
-        back()
-        app.swipeUp()
-
-        let acknowledgements = app.buttons["Acknowledgements"]
-        _ = acknowledgements.waitForExistence(timeout: timeout)
-        acknowledgements.tap()
-
-        back()
-
-        app.swipeUp()
-
-        let privacyPolicy = app.buttons["Privacy Policy"]
-        _ = privacyPolicy.waitForExistence(timeout: timeout)
-        privacyPolicy.tap()
-
-        let privacyPolicyLabel = app.staticTexts["General Information"]
-        let privacyPageLoaded = privacyPolicyLabel.waitForExistence(timeout: timeout)
-        XCTAssertTrue(privacyPageLoaded)
-
-        back()
-
-        let terms = app.buttons["Terms of Service"]
-        _ = terms.waitForExistence(timeout: timeout)
-        terms.tap()
-
-        let termsOfServiceLabel = app.staticTexts["About our Terms of Service"]
-        let termsPageLoaded = termsOfServiceLabel.waitForExistence(timeout: timeout)
-        XCTAssertTrue(termsPageLoaded)
-
-        back()
+        try MainContentRobot(app)
+            .startWithSignIn()
+            .tapSettings()
+            .tapAppIcon()
+            .back()
+            .tapDebugMenu()
+            .back()
+            .swipeUp()
+            .tapAcknowledgements()
+            .back()
+            .swipeUp()
+            .tapPrivacyPolicy()
+            .checkGeneralInformation()
+            .backToSettings()
+            .tapTerms()
+            .checkAbout()
+            .backToSettings()
     }
 
     /// Just remember that GitHub is running its own navigation control with JavaScript/whatever/replacing the page

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -34,26 +34,13 @@ final class BikeIndexUITests: XCTestCase {
 
     /// Sometimes this fails when a page plainly fails to load, may need to add more resiliency.
     func test_basic_bike_detail_navigation() throws {
-        app.launch()
-        try signIn(app: app)
-
-        let bike1 = app.buttons["Bike 1"]
-        _ = bike1.waitForExistence(timeout: timeout)
-        bike1.tap()
-
-        // On-page
-        let webViewEdit = app.buttons["Edit"]
-        _ = webViewEdit.waitForExistence(timeout: timeout)
-        webViewEdit.tap()
-
-        let webViewBikeView = app.links["View Bike"]
-        _ = webViewBikeView.waitForExistence(timeout: timeout)
-        webViewBikeView.tap()
-
-        _ = webViewEdit.waitForExistence(timeout: timeout)
-        webViewEdit.tap()
-
-        back()
+        try Robot(app)
+            .startWithSignIn()
+            .tapFirstBike()
+            .tapEditButton()
+            .tapViewBikeButton()
+            .tapEditButton()
+            .back()
     }
 
     func test_basic_settings_navigation() throws {

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -101,22 +101,12 @@ final class BikeIndexUITests: XCTestCase {
     }
 
     func test_serial_page_navigation() throws {
-        app.launch()
-        try signIn(app: app)
-
-        let registerBikeButton = app.buttons["Register a bike"]
-        _ = registerBikeButton.waitForExistence(timeout: timeout)
-        registerBikeButton.tap()
-
-        let goToOurSerialPage = app.staticTexts.matching(
-            NSPredicate(format: "label BEGINSWITH %@", "Every bike has a unique"))
-        if goToOurSerialPage.element.waitForExistence(timeout: timeout) {
-            goToOurSerialPage.element.tap()
-        } else {
-            XCTFail("Expected markdown link at 'go to our serial page'")
-        }
-
-        back()
+        try MainContentRobot(app)
+            .startWithSignIn()
+            .tapRegisterBikeButton()
+            .tapGoToOurSerialPage()
+            .checkSerialPageLoaded()
+            .back()
     }
 
     func test_register_bike_stolen_guide_link() throws {

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -110,24 +110,11 @@ final class BikeIndexUITests: XCTestCase {
     }
 
     func test_register_bike_stolen_guide_link() throws {
-        app.launch()
-        try signIn(app: app)
-
-        let registerBikeButton = app.buttons["Register a stolen bike"]
-        _ = registerBikeButton.waitForExistence(timeout: timeout)
-        registerBikeButton.tap()
-
-        let whatToDoIfYourBikeIStolenPage = app.buttons["What to do if your bike is stolen"]
-        _ = whatToDoIfYourBikeIStolenPage.waitForExistence(timeout: timeout)
-        whatToDoIfYourBikeIStolenPage.tap()
-
-        back()
-
-        let goToHowToGetYourBikeBackPage = app.buttons["How to get your stolen bike back"]
-        _ = goToHowToGetYourBikeBackPage.waitForExistence(timeout: timeout)
-        goToHowToGetYourBikeBackPage.tap()
-
-        back()
+        try MainContentRobot(app)
+            .startWithSignIn()
+            .tapRegisterStolenBikeButton()
+            .checkWhatToDoPageLoads()
+            .checkHowToPageLoads()
     }
 
     func test_settings_account_pages() throws {

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -118,37 +118,25 @@ final class BikeIndexUITests: XCTestCase {
     }
 
     func test_settings_account_pages() throws {
-        app.launch()
-        try signIn(app: app)
+        try MainContentRobot(app)
+            .startWithSignIn()
+            .tapSettings()
 
-        openSettings()
+            .tapUserSettings()
+            .checkTextExists("Give us permission to contact you if we believe your bike has been stolen, even if it isn't marked stolen")
+            .back()
 
-        button(named: "User Settings")
-            .tap()
-        let userSettingsConfirmation = app.staticTexts[
-            "Give us permission to contact you if we believe your bike has been stolen, even if it isn't marked stolen"
-        ]
-        _ = userSettingsConfirmation.waitForExistence(timeout: timeout)
-        back()
+            .tapPassword()
+            .checkTextExists("Password must be at least 12 characters. Longer is")
+            .back()
 
-        button(named: "Password")
-            .tap()
-        let resetPassword = app.staticTexts["Password must be at least 12 characters. Longer is"]
-        _ = resetPassword.waitForExistence(timeout: timeout)
-        back()
+            .tapSharingAndPersonalPage()
+            .checkTextExists("Show Personal Site")
+            .back()
 
-        button(named: "Sharing + Personal Page")
-            .tap()
-        let sharingPageConfirmation = app.staticTexts["Show Personal Site"]
-        _ = sharingPageConfirmation.waitForExistence(timeout: timeout)
-        back()
-
-        button(named: "Registration Organization")
-            .tap()
-        let regOrgsConfirmation = app.staticTexts[
-            "Manage the organizations your bikes are registered with."]
-        _ = regOrgsConfirmation.waitForExistence(timeout: timeout)
-        back()
+            .tapRegistrationOrganization()
+            .checkTextExists("Manage the organizations your bikes are registered with.")
+            .back()
     }
 
     // MARK: - Helpers

--- a/UITests/EditBikeRobot.swift
+++ b/UITests/EditBikeRobot.swift
@@ -1,0 +1,17 @@
+//
+//  EditBikeRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/2/25.
+//
+
+final class EditBikeRobot: Robot {
+    lazy var viewBikeButton = app.links["View Bike"]
+
+    @discardableResult
+    func tapViewBikeButton() -> BikeDetailRobot {
+        tap(viewBikeButton)
+
+        return BikeDetailRobot(app)
+    }
+}

--- a/UITests/MainContentRobot/MainContentRobot.swift
+++ b/UITests/MainContentRobot/MainContentRobot.swift
@@ -1,0 +1,26 @@
+//
+//  MainContentRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/7/25.
+//
+
+/// Robot for testing the main content page.
+final class MainContentRobot: Robot {
+    lazy var settingsButton = navigationBar.buttons["Settings"]
+    lazy var firstBike = app.buttons["Bike 1"]
+
+    @discardableResult
+    func tapSettings() -> SettingsRobot {
+        tap(settingsButton)
+
+        return SettingsRobot(app)
+    }
+
+    @discardableResult
+    func tapFirstBike() -> BikeDetailRobot {
+        tap(firstBike)
+
+        return BikeDetailRobot(app)
+    }
+}

--- a/UITests/RegisterBikeRobot.swift
+++ b/UITests/RegisterBikeRobot.swift
@@ -1,0 +1,25 @@
+//
+//  RegisterBikeRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/9/25.
+//
+
+import Foundation
+
+final class RegisterBikeRobot: Robot {
+    lazy var goToOurSerialPage = app.staticTexts.matching(
+        NSPredicate(format: "label BEGINSWITH %@", "Every bike has a unique")
+    ).element
+    lazy var serialPageHeading = app.webViews.staticTexts["BIKE SERIAL NUMBERS"]
+
+    @discardableResult
+    func tapGoToOurSerialPage() -> Self {
+        tap(goToOurSerialPage)
+    }
+
+    @discardableResult
+    func checkSerialPageLoaded() -> Self {
+        assert(serialPageHeading, [.exists])
+    }
+}

--- a/UITests/RegisterStolenBikeRobot.swift
+++ b/UITests/RegisterStolenBikeRobot.swift
@@ -1,0 +1,28 @@
+//
+//  RegisterStolenBikeRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/9/25.
+//
+
+final class RegisterStolenBikeRobot: Robot {
+    lazy var whatToDoButton = app.buttons["What to do if your bike is stolen"]
+    lazy var whatToDoPageHeading = app.webViews.staticTexts["WHAT TO DO IF YOUR BIKE IS STOLEN"]
+
+    lazy var howToButton = app.buttons["How to get your stolen bike back"]
+    lazy var howToPageHeading = app.webViews.staticTexts["How to get your stolen bike back"]
+
+    @discardableResult
+    func checkWhatToDoPageLoads() -> Self {
+        tap(whatToDoButton)
+            .assert(whatToDoPageHeading, [.exists])
+            .back()
+    }
+
+    @discardableResult
+    func checkHowToPageLoads() -> Self {
+        tap(howToButton)
+            .assert(howToPageHeading, [.exists])
+            .back()
+    }
+}

--- a/UITests/Robot/MainContentRobot.swift
+++ b/UITests/Robot/MainContentRobot.swift
@@ -9,6 +9,7 @@
 final class MainContentRobot: Robot {
     lazy var settingsButton = navigationBar.buttons["Settings"]
     lazy var firstBike = app.buttons["Bike 1"]
+    lazy var registerBikeButton = app.buttons["Register a bike"]
 
     @discardableResult
     func tapSettings() -> SettingsRobot {
@@ -22,5 +23,12 @@ final class MainContentRobot: Robot {
         tap(firstBike)
 
         return BikeDetailRobot(app)
+    }
+
+    @discardableResult
+    func tapRegisterBikeButton() -> RegisterBikeRobot {
+        tap(registerBikeButton)
+
+        return RegisterBikeRobot(app)
     }
 }

--- a/UITests/Robot/MainContentRobot.swift
+++ b/UITests/Robot/MainContentRobot.swift
@@ -8,6 +8,7 @@
 /// Robot for testing the main content page.
 final class MainContentRobot: Robot {
     lazy var settingsButton = navigationBar.buttons["Settings"]
+    lazy var helpButton = navigationBar.buttons["Help"]
     lazy var firstBike = app.buttons["Bike 1"]
     lazy var registerBikeButton = app.buttons["Register a bike"]
     lazy var registerStolenBikeButton = app.buttons["Register a stolen bike"]
@@ -17,6 +18,11 @@ final class MainContentRobot: Robot {
         tap(settingsButton)
 
         return SettingsRobot(app)
+    }
+
+    @discardableResult
+    func tapHelpButton() -> Self {
+        tap(helpButton)
     }
 
     @discardableResult

--- a/UITests/Robot/MainContentRobot.swift
+++ b/UITests/Robot/MainContentRobot.swift
@@ -10,6 +10,7 @@ final class MainContentRobot: Robot {
     lazy var settingsButton = navigationBar.buttons["Settings"]
     lazy var firstBike = app.buttons["Bike 1"]
     lazy var registerBikeButton = app.buttons["Register a bike"]
+    lazy var registerStolenBikeButton = app.buttons["Register a stolen bike"]
 
     @discardableResult
     func tapSettings() -> SettingsRobot {
@@ -30,5 +31,12 @@ final class MainContentRobot: Robot {
         tap(registerBikeButton)
 
         return RegisterBikeRobot(app)
+    }
+
+    @discardableResult
+    func tapRegisterStolenBikeButton() -> RegisterStolenBikeRobot {
+        tap(registerStolenBikeButton)
+
+        return RegisterStolenBikeRobot(app)
     }
 }

--- a/UITests/Robot/Predicate.swift
+++ b/UITests/Robot/Predicate.swift
@@ -13,6 +13,9 @@ extension Robot {
         case exists
         case doesNotExist
 
+        case isEnabled
+        case isNotEnabled
+
         case isHittable
         case isNotHittable
 
@@ -26,6 +29,10 @@ extension Robot {
                 return "exists == true"
             case .doesNotExist:
                 return "exists == false"
+            case .isEnabled:
+                return "isEnabled == true"
+            case .isNotEnabled:
+                return "isEnabled == false"
             case .isHittable:
                 return "isHittable == true"
             case .isNotHittable:

--- a/UITests/Robot/Robot+Authentication.swift
+++ b/UITests/Robot/Robot+Authentication.swift
@@ -11,10 +11,8 @@ import XCTest
 extension Robot {
     @discardableResult
     func startWithSignIn() throws -> Self {
-        start()
-        try signIn()
-
-        return self
+        try start()
+            .signIn()
     }
 
     // TODO: Refactor method to use Robot pattern

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -5,7 +5,6 @@
 //  Created by Milo Wyner on 6/20/25.
 //
 
-import OSLog
 import XCTest
 
 /// From Robot Pattern for UI testing: https://jhandguy.github.io/posts/robot-pattern-ios/
@@ -25,9 +24,7 @@ class Robot {
     @discardableResult
     func start(timeout: TimeInterval = Robot.defaultTimeout) -> Self {
         app.launch()
-        assert(app, [.exists], timeout: timeout)
-
-        return self
+        return assert(app, [.exists], timeout: timeout)
     }
 
     @discardableResult
@@ -57,8 +54,6 @@ class Robot {
     @discardableResult
     func back(timeout: TimeInterval = Robot.defaultTimeout) -> Self {
         tap(navigationBarButton, timeout: timeout)
-
-        return self
     }
 
     @discardableResult

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -14,6 +14,10 @@ class Robot {
 
     var app: XCUIApplication
 
+    lazy var navigationBar = app.navigationBars.firstMatch
+    lazy var navigationBarButton = navigationBar.buttons.firstMatch
+    lazy var firstBike = app.buttons["Bike 1"]
+
     init(_ app: XCUIApplication, defaultTimeout: TimeInterval = Robot.defaultTimeout) {
         self.app = app
         Robot.defaultTimeout = defaultTimeout
@@ -49,6 +53,20 @@ class Robot {
         }
 
         return self
+    }
+
+    @discardableResult
+    func back(timeout: TimeInterval = Robot.defaultTimeout) -> Self {
+        tap(navigationBarButton, timeout: timeout)
+
+        return self
+    }
+
+    @discardableResult
+    func tapFirstBike() -> BikeDetailRobot {
+        tap(firstBike)
+
+        return BikeDetailRobot(app)
     }
 
 }

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -9,7 +9,7 @@ import XCTest
 
 /// From Robot Pattern for UI testing: https://jhandguy.github.io/posts/robot-pattern-ios/
 class Robot {
-    private static var defaultTimeout: Double = 60
+    static var defaultTimeout: Double = 60
 
     var app: XCUIApplication
 
@@ -44,7 +44,9 @@ class Robot {
             predicate: NSPredicate(format: predicates.map { $0.format }.joined(separator: " AND ")),
             object: element)
         guard XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed else {
-            XCTFail("[\(self)] Element \(element.description) did not fulfill expectation: \(predicates.map { $0.format })")
+            XCTFail(
+                "[\(self)] Element \(element.description) did not fulfill expectation: \(predicates.map { $0.format })"
+            )
             return self
         }
 

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -13,14 +13,9 @@ class Robot {
     private static var defaultTimeout: Double = 60
 
     var app: XCUIApplication
-    var testCase: XCTestCase
 
-    init(
-        app: XCUIApplication, testCase: XCTestCase,
-        defaultTimeout: TimeInterval = Robot.defaultTimeout
-    ) {
+    init(_ app: XCUIApplication, defaultTimeout: TimeInterval = Robot.defaultTimeout) {
         self.app = app
-        self.testCase = testCase
         Robot.defaultTimeout = defaultTimeout
     }
 
@@ -48,7 +43,10 @@ class Robot {
         let expectation = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: predicates.map { $0.format }.joined(separator: " AND ")),
             object: element)
-        testCase.wait(for: [expectation], timeout: timeout)
+        guard XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed else {
+            XCTFail("[\(self)] Element \(element.description) did not fulfill expectation: \(predicates.map { $0.format })")
+            return self
+        }
 
         return self
     }

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -16,7 +16,6 @@ class Robot {
 
     lazy var navigationBar = app.navigationBars.firstMatch
     lazy var navigationBarButton = navigationBar.buttons.firstMatch
-    lazy var firstBike = app.buttons["Bike 1"]
 
     init(_ app: XCUIApplication, defaultTimeout: TimeInterval = Robot.defaultTimeout) {
         self.app = app
@@ -63,10 +62,9 @@ class Robot {
     }
 
     @discardableResult
-    func tapFirstBike() -> BikeDetailRobot {
-        tap(firstBike)
+    func swipeUp() -> Self {
+        app.swipeUp()
 
-        return BikeDetailRobot(app)
+        return self
     }
-
 }

--- a/UITests/SettingsRobot/AcknowledgementsRobot.swift
+++ b/UITests/SettingsRobot/AcknowledgementsRobot.swift
@@ -1,0 +1,23 @@
+//
+//  AcknowledgementsRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/7/25.
+//
+
+final class AcknowledgementsRobot: Robot, NavigatesBackToSettings {
+    lazy var iOS_repo = app.collectionViews.cells.element(boundBy: 2)
+    lazy var linkButton = app.buttons["Open Repository"]
+
+    @discardableResult
+    func tap_iOS_repo() -> Self {
+        tap(iOS_repo)
+    }
+
+    @discardableResult
+    func tapLinkButton() -> WebViewRobot {
+        tap(linkButton)
+
+        return WebViewRobot(app)
+    }
+}

--- a/UITests/SettingsRobot/NavigatesBackToSettings.swift
+++ b/UITests/SettingsRobot/NavigatesBackToSettings.swift
@@ -1,0 +1,20 @@
+//
+//  NavigatesBackToSettings.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/7/25.
+//
+
+/// Overrides back() method to return SettingsRobot.
+protocol NavigatesBackToSettings: Robot {
+    func back() -> SettingsRobot
+}
+
+extension NavigatesBackToSettings {
+    @discardableResult
+    func back() -> SettingsRobot {
+        back()
+
+        return SettingsRobot(app)
+    }
+}

--- a/UITests/SettingsRobot/PrivacyPolicyRobot.swift
+++ b/UITests/SettingsRobot/PrivacyPolicyRobot.swift
@@ -5,15 +5,8 @@
 //  Created by Milo Wyner on 7/2/25.
 //
 
-final class PrivacyPolicyRobot: Robot {
+final class PrivacyPolicyRobot: Robot, NavigatesBackToSettings {
     lazy var generalInformation = app.staticTexts["General Information"]
-
-    @discardableResult
-    func backToSettings() -> SettingsRobot {
-        back()
-
-        return SettingsRobot(app)
-    }
 
     @discardableResult
     func checkGeneralInformation() -> Self {

--- a/UITests/SettingsRobot/PrivacyPolicyRobot.swift
+++ b/UITests/SettingsRobot/PrivacyPolicyRobot.swift
@@ -1,0 +1,22 @@
+//
+//  PrivacyPolicyRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/2/25.
+//
+
+final class PrivacyPolicyRobot: Robot {
+    lazy var generalInformation = app.staticTexts["General Information"]
+
+    @discardableResult
+    func backToSettings() -> SettingsRobot {
+        back()
+
+        return SettingsRobot(app)
+    }
+
+    @discardableResult
+    func checkGeneralInformation() -> Self {
+        assert(generalInformation, [.exists])
+    }
+}

--- a/UITests/SettingsRobot/SettingsRobot.swift
+++ b/UITests/SettingsRobot/SettingsRobot.swift
@@ -1,0 +1,44 @@
+//
+//  SettingsRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/2/25.
+//
+
+/// Robot for testing the settings page.
+final class SettingsRobot: Robot {
+    lazy var appIcon = app.buttons["App Icon"]
+    lazy var debugMenu = app.buttons["Debug menu"]
+    lazy var acknowledgements = app.buttons["Acknowledgements"]
+    lazy var privacyPolicy = app.buttons["Privacy Policy"]
+    lazy var terms = app.buttons["Terms of Service"]
+
+    @discardableResult
+    func tapAppIcon() -> Self {
+        tap(appIcon)
+    }
+
+    @discardableResult
+    func tapDebugMenu() -> Self {
+        tap(debugMenu)
+    }
+
+    @discardableResult
+    func tapAcknowledgements() -> Self {
+        tap(acknowledgements)
+    }
+
+    @discardableResult
+    func tapPrivacyPolicy() -> PrivacyPolicyRobot {
+        tap(privacyPolicy)
+
+        return PrivacyPolicyRobot(app)
+    }
+
+    @discardableResult
+    func tapTerms() -> TermsOfServiceRobot {
+        tap(terms)
+
+        return TermsOfServiceRobot(app)
+    }
+}

--- a/UITests/SettingsRobot/SettingsRobot.swift
+++ b/UITests/SettingsRobot/SettingsRobot.swift
@@ -24,8 +24,10 @@ final class SettingsRobot: Robot {
     }
 
     @discardableResult
-    func tapAcknowledgements() -> Self {
+    func tapAcknowledgements() -> AcknowledgementsRobot {
         tap(acknowledgements)
+
+        return AcknowledgementsRobot(app)
     }
 
     @discardableResult

--- a/UITests/SettingsRobot/SettingsRobot.swift
+++ b/UITests/SettingsRobot/SettingsRobot.swift
@@ -8,7 +8,17 @@
 /// Robot for testing the settings page.
 final class SettingsRobot: Robot {
     lazy var appIcon = app.buttons["App Icon"]
+
+    /// Manage Account
+    lazy var userSettings = app.buttons["User Settings"]
+    lazy var password = app.buttons["Password"]
+    lazy var sharingAndPersonalPage = app.buttons["Sharing + Personal Page"]
+    lazy var registrationOrganization = app.buttons["Registration Organization"]
+
+    /// Developer
     lazy var debugMenu = app.buttons["Debug menu"]
+
+    /// About
     lazy var acknowledgements = app.buttons["Acknowledgements"]
     lazy var privacyPolicy = app.buttons["Privacy Policy"]
     lazy var terms = app.buttons["Terms of Service"]
@@ -16,6 +26,26 @@ final class SettingsRobot: Robot {
     @discardableResult
     func tapAppIcon() -> Self {
         tap(appIcon)
+    }
+
+    @discardableResult
+    func tapUserSettings() -> Self {
+        tap(userSettings)
+    }
+
+    @discardableResult
+    func tapPassword() -> Self {
+        tap(password)
+    }
+
+    @discardableResult
+    func tapSharingAndPersonalPage() -> Self {
+        tap(sharingAndPersonalPage)
+    }
+
+    @discardableResult
+    func tapRegistrationOrganization() -> Self {
+        tap(registrationOrganization)
     }
 
     @discardableResult
@@ -42,5 +72,10 @@ final class SettingsRobot: Robot {
         tap(terms)
 
         return TermsOfServiceRobot(app)
+    }
+
+    @discardableResult
+    func checkTextExists(_ text: String) -> Self {
+        assert(app.staticTexts[text], [.exists])
     }
 }

--- a/UITests/SettingsRobot/TermsOfServiceRobot.swift
+++ b/UITests/SettingsRobot/TermsOfServiceRobot.swift
@@ -5,15 +5,8 @@
 //  Created by Milo Wyner on 7/2/25.
 //
 
-final class TermsOfServiceRobot: Robot {
+final class TermsOfServiceRobot: Robot, NavigatesBackToSettings {
     lazy var about = app.staticTexts["About our Terms of Service"]
-
-    @discardableResult
-    func backToSettings() -> SettingsRobot {
-        back()
-
-        return SettingsRobot(app)
-    }
 
     @discardableResult
     func checkAbout() -> Self {

--- a/UITests/SettingsRobot/TermsOfServiceRobot.swift
+++ b/UITests/SettingsRobot/TermsOfServiceRobot.swift
@@ -1,0 +1,22 @@
+//
+//  TermsOfServiceRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/2/25.
+//
+
+final class TermsOfServiceRobot: Robot {
+    lazy var about = app.staticTexts["About our Terms of Service"]
+
+    @discardableResult
+    func backToSettings() -> SettingsRobot {
+        back()
+
+        return SettingsRobot(app)
+    }
+
+    @discardableResult
+    func checkAbout() -> Self {
+        assert(about, [.exists])
+    }
+}

--- a/UITests/UniversalLinksRobot.swift
+++ b/UITests/UniversalLinksRobot.swift
@@ -12,7 +12,7 @@ final class UniversalLinksRobot: Robot {
     private lazy var unlinkedMessage: [XCUIElement] = [
         app.webViews.staticTexts["You scanned the sticker"],
         app.webViews.staticTexts["A 403 40"],
-        app.webViews.staticTexts[", which is assigned to this bike."]
+        app.webViews.staticTexts[", which is assigned to this bike."],
     ]
 
     @discardableResult

--- a/UITests/UniversalLinksUITest.swift
+++ b/UITests/UniversalLinksUITest.swift
@@ -15,7 +15,7 @@ extension BikeIndexUITests {
 
     /// Sometimes this fails when a page plainly fails to load, may need to add more resiliency.
     func test_authenticated_bikes_scanned_id_universal_link() throws {
-        try UniversalLinksRobot(app: app, testCase: self)
+        try UniversalLinksRobot(app)
             .startWithSignIn()
             .openLink()
             .checkStickerHeader()

--- a/UITests/WebViewRobot.swift
+++ b/UITests/WebViewRobot.swift
@@ -1,0 +1,70 @@
+//
+//  WebViewRobot.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 7/7/25.
+//
+
+import XCUIAutomation
+
+final class WebViewRobot: Robot {
+    lazy var backButton = app.buttons["WebViewBack"]
+    lazy var forwardButton = app.buttons["WebViewForward"]
+
+    @discardableResult
+    func checkBackButton(isEnabled: Bool) -> Self {
+        check(backButton, isEnabled: isEnabled)
+    }
+
+    @discardableResult
+    func checkForwardButton(isEnabled: Bool) -> Self {
+        check(forwardButton, isEnabled: isEnabled)
+    }
+
+    @discardableResult
+    func checkDocumentationLink() -> Self {
+        assert(link(with: "/documentation"), [.exists])
+    }
+
+    @discardableResult
+    func tapOauthLink() -> Self {
+        tapLink(link(with: "https://bikeindex.org/oauth/applications"))
+    }
+
+    @discardableResult
+    func tapBackButton() -> Self {
+        tap(backButton)
+    }
+
+    @discardableResult
+    func tapViewAllFilesIfNeeded(timeout: TimeInterval = Robot.defaultTimeout) -> Self {
+        // Conditional because iPad has enough space to display LICENSE.txt without tapping "View all files"
+        let viewAllFiles = app.webViews.buttons["View all files"]
+        if viewAllFiles.waitForExistence(timeout: timeout) {
+            viewAllFiles.tap()
+        }
+
+        return self
+    }
+
+    @discardableResult
+    func tapLicenseTxt() -> Self {
+        tapLink(link(with: "LICENSE.txt"))
+    }
+
+    private func check(_ element: XCUIElement, isEnabled: Bool) -> Self {
+        assert(element, [isEnabled ? .isEnabled : .isNotEnabled])
+    }
+
+    /// Links may not be hittable if off screen, so check if exists instead before tapping.
+    private func tapLink(_ link: XCUIElement) -> Self {
+        assert(link, [.exists])
+        link.tap()
+
+        return self
+    }
+
+    private func link(with prefix: String) -> XCUIElement {
+        app.links.matching(NSPredicate(format: "label BEGINSWITH %@", prefix)).element
+    }
+}


### PR DESCRIPTION
# Description

- Implement the next stage of adopting the Robot Pattern for UI testing by applying it to all the tests in BikeIndexUITests.swift.
- This mainly just translates the previous tests to the new pattern.
- But there were some tests that weren't actually waiting for elements to exist, so this fixes those like with the previous Universal Links test adoption PR.

## Screenshots

| Example of previous test | Example of new test |
| --- | --- |
| <img width="710" height="828" alt="Screenshot 2025-07-15 at 5 09 45 PM" src="https://github.com/user-attachments/assets/000b7eb6-6470-47fc-ad23-6f0b70df290a" /> | <img width="427" height="355" alt="Screenshot 2025-07-15 at 5 10 59 PM" src="https://github.com/user-attachments/assets/70431c7b-2bb1-4f88-b84b-53e676ee2a0b" /> |