### PR TITLE
Simplify Scope queryItem joining

### DIFF
--- a/BikeIndex/Model/Authentication/AuthenticatedUserResponse.swift
+++ b/BikeIndex/Model/Authentication/AuthenticatedUserResponse.swift
@@ -9,13 +9,6 @@ import Foundation
 import OSLog
 import SwiftData
 
-/// Convert a network response from a Decodable struct into its corresponding @Model class instance.
-protocol ResponseModelInstantiable: Decodable {
-    associatedtype ModelInstance
-
-    func modelInstance() -> ModelInstance
-}
-
 struct AuthenticatedUserResponse: Decodable, ResponseModelInstantiable {
     typealias ModelInstance = AuthenticatedUser
 

--- a/BikeIndex/Model/Authentication/OAuthToken.swift
+++ b/BikeIndex/Model/Authentication/OAuthToken.swift
@@ -70,20 +70,3 @@ extension OAuthToken {
         Date() < expiration
     }
 }
-
-enum Scope: String, CaseIterable, Identifiable {
-    var id: Self { self }
-
-    case readUser = "read_user"
-    case writeUser = "write_user"
-
-    case readBikes = "read_bikes"
-    case writeBikes = "write_bikes"
-}
-
-extension [Scope] {
-    /// Transform this array of `Scope` to be used in an API request for the sign-in page.
-    var queryItem: String {
-        self.map { $0.rawValue }.joined(separator: "+")
-    }
-}

--- a/BikeIndex/Model/Authentication/OAuthToken.swift
+++ b/BikeIndex/Model/Authentication/OAuthToken.swift
@@ -82,12 +82,8 @@ enum Scope: String, CaseIterable, Identifiable {
 }
 
 extension [Scope] {
-    /// Transform `self` (an array of ``Scope``s) into a string delimited by plus signs
-    /// that only occur between ``Scope`` values. (Do not add a trailing "+").
+    /// Transform this array of `Scope` to be used in an API request for the sign-in page.
     var queryItem: String {
-        self.enumerated().reduce(into: "") { partialResult, iteration in
-            partialResult += iteration.element.rawValue
-            partialResult += (iteration.offset + 1 < self.count) ? "+" : ""
-        }
+        self.map { $0.rawValue }.joined(separator: "+")
     }
 }

--- a/BikeIndex/Model/Authentication/Scope.swift
+++ b/BikeIndex/Model/Authentication/Scope.swift
@@ -1,0 +1,25 @@
+//
+//  Scope.swift
+//  BikeIndex
+//
+//  Created by Jack on 8/9/25.
+//
+
+import Foundation
+
+enum Scope: String, CaseIterable, Identifiable {
+    var id: Self { self }
+
+    case readUser = "read_user"
+    case writeUser = "write_user"
+
+    case readBikes = "read_bikes"
+    case writeBikes = "write_bikes"
+}
+
+extension [Scope] {
+    /// Transform this array of `Scope` to be used in an API request for the sign-in page.
+    var queryItem: String {
+        self.map { $0.rawValue }.joined(separator: "+")
+    }
+}

--- a/BikeIndex/Model/ResponseModelInstantiable.swift
+++ b/BikeIndex/Model/ResponseModelInstantiable.swift
@@ -1,0 +1,15 @@
+//
+//  into.swift
+//  BikeIndex
+//
+//  Created by Jack on 8/1/25.
+//
+
+import Foundation
+
+/// Convert a network response from a Decodable struct into its corresponding @Model class instance.
+protocol ResponseModelInstantiable: Decodable {
+    associatedtype ModelInstance
+
+    func modelInstance() -> ModelInstance
+}

--- a/BikeIndex/Model/ResponseModelInstantiable.swift
+++ b/BikeIndex/Model/ResponseModelInstantiable.swift
@@ -2,7 +2,7 @@
 //  into.swift
 //  BikeIndex
 //
-//  Created by Jack on 8/1/25.
+//  Created by Jack on 8/9/25.
 //
 
 import Foundation

--- a/UnitTests/OAuthTests.swift
+++ b/UnitTests/OAuthTests.swift
@@ -5,23 +5,32 @@
 //  Created by Jack on 11/18/23.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import BikeIndex
 
-final class OAuthTests: XCTestCase {
-
-    func test_oauth_parsing() throws {
+struct OAuthTests {
+    @Test func test_oauth_parsing() throws {
         let input = MockData.fullToken
         let rawJsonData = input.data(using: .utf8).unsafelyUnwrapped
         let output = try JSONDecoder().decode(OAuthToken.self, from: rawJsonData)
 
-        XCTAssertEqual(output.accessToken, "vQclXy6QL-OZJnYP88mpjGJXiK8KkwHwCrpMDezLedY")
-        XCTAssertEqual(output.tokenType, "Bearer")
-        XCTAssertEqual(output.expiresIn, 3_600)
-        XCTAssertEqual(output.refreshToken, "-Y8FDaHbr3F6KauqtFINsPvIjziN9DCIbdGEy8GS-tM")
-        XCTAssertEqual(output.scope, Scope.allCases)
-        XCTAssertEqual(output.createdAt.timeIntervalSince1970, 1_698_883_930)
+        #expect(output.accessToken == "vQclXy6QL-OZJnYP88mpjGJXiK8KkwHwCrpMDezLedY")
+        #expect(output.tokenType == "Bearer")
+        #expect(output.expiresIn == 3_600)
+        #expect(output.refreshToken == "-Y8FDaHbr3F6KauqtFINsPvIjziN9DCIbdGEy8GS-tM")
+        #expect(output.scope == Scope.allCases)
+        #expect(output.createdAt.timeIntervalSince1970 == 1_698_883_930)
+    }
 
+    @Test func test_oauth_queryItem() {
+        #expect(Scope.allCases.queryItem == "read_user+write_user+read_bikes+write_bikes")
+
+        let readOnlyScopes: [Scope] = [.readUser, .readBikes]
+        #expect(readOnlyScopes.queryItem == "read_user+read_bikes")
+
+        let writeOnlyScopes: [Scope] = [.writeUser, .writeBikes]
+        #expect(writeOnlyScopes.queryItem == "write_user+write_bikes")
     }
 }


### PR DESCRIPTION
# Description

- Simplify Scope array `queryItem` function to combine scopes separated by `+`
    - A trialing `+` will be rejected by the API so make sure that doesn't happen with unit tests
- Move ResponseModelInstantiable to its own file
- Rewrite OAuthTests in Swift Testing