### PR TITLE
Feat: Add FrameColorBackground to ContentBikeButton (main grid)

### DIFF
--- a/BikeIndex/Model/FrameColor.swift
+++ b/BikeIndex/Model/FrameColor.swift
@@ -91,9 +91,12 @@ extension FrameColor {
 }
 
 extension FrameColor {
+    // swift-format-ignore: NoPlaygroundLiterals
     /// Display colors provided by ``Selections/colors`` (not fetched from API)
     /// and hard-coded for convenience.
     /// Combine with SwiftUI-default ``color`` values to create custom gradients.
+    /// swiftlang/swift-format playground literals warnings are ignored because
+    /// these selections/colors values are only available in 1 theme at this time.
     var prettyColor: Color? {
         switch self {
         case .black:

--- a/BikeIndex/Model/FrameColor.swift
+++ b/BikeIndex/Model/FrameColor.swift
@@ -30,7 +30,7 @@ enum FrameColor: String, Codable, CaseIterable, Identifiable, Equatable {
 
     // MARK: -
 
-    var id: String { rawValue }
+    var id: Self { self }
 
     var displayValue: String { rawValue }
 
@@ -56,6 +56,8 @@ enum FrameColor: String, Codable, CaseIterable, Identifiable, Equatable {
 }
 
 extension FrameColor {
+    /// SwiftUI provided colors for frame display.
+    /// Combine with BikeIndex-specific ``prettyColor`` values to create custom gradients.
     var color: Color? {
         switch self {
         case .bareMetal, .covered:
@@ -89,6 +91,9 @@ extension FrameColor {
 }
 
 extension FrameColor {
+    /// Display colors provided by ``Selections/colors`` (not fetched from API)
+    /// and hard-coded for convenience.
+    /// Combine with SwiftUI-default ``color`` values to create custom gradients.
     var prettyColor: Color? {
         switch self {
         case .black:
@@ -98,7 +103,7 @@ extension FrameColor {
         case .brown:
             Color(#colorLiteral(red: 0.451, green: 0.29, blue: 0.133, alpha: 1))  // #734a22
         case .green:
-            Color(#colorLiteral(red: 0.106, green: 0.631, blue: 0, alpha: 1))  // #1ba100<#code#>
+            Color(#colorLiteral(red: 0.106, green: 0.631, blue: 0, alpha: 1))  // #1ba100
         case .orange:
             Color(#colorLiteral(red: 1, green: 0.553, blue: 0.114, alpha: 1))  // #ff8d1d
         case .pink:
@@ -108,7 +113,7 @@ extension FrameColor {
         case .red:
             Color(#colorLiteral(red: 0.925, green: 0.075, blue: 0.075, alpha: 1))  // #ec1313
         case .bareMetal:
-            // NOTE: normally nil!
+            /// NOTE: typically nil from ``FrameColor/color``
             Color(#colorLiteral(red: 0.69, green: 0.69, blue: 0.69, alpha: 1))  // #b0b0b0
         case .covered:
             nil
@@ -119,5 +124,13 @@ extension FrameColor {
         case .yellow:
             Color(#colorLiteral(red: 1, green: 0.957, blue: 0.294, alpha: 1))  // #fff44b
         }
+    }
+}
+
+extension FrameColor {
+    /// Will evaluate to empty array for ``bareMetal`` and ``covered`` cases.
+    @MainActor
+    var gradientColors: [Color] {
+        [color, prettyColor].compactMap { $0 }
     }
 }

--- a/BikeIndex/Model/FrameColor.swift
+++ b/BikeIndex/Model/FrameColor.swift
@@ -42,17 +42,6 @@ enum FrameColor: String, Codable, CaseIterable, Identifiable, Equatable {
         .red, .pink, .orange, .yellow, .green, .teal, .blue, .purple, .brown, .black, .white,
         .bareMetal, .covered,
     ]
-
-    /// A `true` value Indicates that this color is displayed with a special View (such as a gradient)
-    /// or a `false` value indicates that this color can be converted to a ``SwiftUICore/Color``
-    var textured: Bool {
-        switch self {
-        case .bareMetal, .covered:
-            true
-        default:
-            false
-        }
-    }
 }
 
 extension FrameColor {

--- a/BikeIndex/Model/FrameColor.swift
+++ b/BikeIndex/Model/FrameColor.swift
@@ -92,32 +92,32 @@ extension FrameColor {
     var prettyColor: Color? {
         switch self {
         case .black:
-            Color(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)) // #000
+            Color(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1))  // #000
         case .blue:
-            Color(#colorLiteral(red: 0.22, green: 0.431, blue: 0.824, alpha: 1)) // #386ed2
+            Color(#colorLiteral(red: 0.22, green: 0.431, blue: 0.824, alpha: 1))  // #386ed2
         case .brown:
-            Color(#colorLiteral(red: 0.451, green: 0.29, blue: 0.133, alpha: 1)) // #734a22
+            Color(#colorLiteral(red: 0.451, green: 0.29, blue: 0.133, alpha: 1))  // #734a22
         case .green:
-            Color(#colorLiteral(red: 0.106, green: 0.631, blue: 0, alpha: 1)) // #1ba100<#code#>
+            Color(#colorLiteral(red: 0.106, green: 0.631, blue: 0, alpha: 1))  // #1ba100<#code#>
         case .orange:
-            Color(#colorLiteral(red: 1, green: 0.553, blue: 0.114, alpha: 1)) // #ff8d1d
+            Color(#colorLiteral(red: 1, green: 0.553, blue: 0.114, alpha: 1))  // #ff8d1d
         case .pink:
-            Color(#colorLiteral(red: 1, green: 0.49, blue: 0.992, alpha: 1)) // #ff7dfd
+            Color(#colorLiteral(red: 1, green: 0.49, blue: 0.992, alpha: 1))  // #ff7dfd
         case .purple:
-            Color(#colorLiteral(red: 0.655, green: 0.271, blue: 0.753, alpha: 1)) // #a745c0
+            Color(#colorLiteral(red: 0.655, green: 0.271, blue: 0.753, alpha: 1))  // #a745c0
         case .red:
-            Color(#colorLiteral(red: 0.925, green: 0.075, blue: 0.075, alpha: 1)) // #ec1313
+            Color(#colorLiteral(red: 0.925, green: 0.075, blue: 0.075, alpha: 1))  // #ec1313
         case .bareMetal:
             // NOTE: normally nil!
-            Color(#colorLiteral(red: 0.69, green: 0.69, blue: 0.69, alpha: 1)) // #b0b0b0
+            Color(#colorLiteral(red: 0.69, green: 0.69, blue: 0.69, alpha: 1))  // #b0b0b0
         case .covered:
             nil
         case .teal:
-            Color(#colorLiteral(red: 0.231, green: 0.929, blue: 0.906, alpha: 1)) // #3bede7
+            Color(#colorLiteral(red: 0.231, green: 0.929, blue: 0.906, alpha: 1))  // #3bede7
         case .white:
-            Color(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)) // #fff
+            Color(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1))  // #fff
         case .yellow:
-            Color(#colorLiteral(red: 1, green: 0.957, blue: 0.294, alpha: 1)) // #fff44b
+            Color(#colorLiteral(red: 1, green: 0.957, blue: 0.294, alpha: 1))  // #fff44b
         }
     }
 }

--- a/BikeIndex/Model/FrameColor.swift
+++ b/BikeIndex/Model/FrameColor.swift
@@ -30,7 +30,7 @@ enum FrameColor: String, Codable, CaseIterable, Identifiable, Equatable {
 
     // MARK: -
 
-    var id: Self { self }
+    var id: String { rawValue }
 
     var displayValue: String { rawValue }
 

--- a/BikeIndex/Model/FrameColor.swift
+++ b/BikeIndex/Model/FrameColor.swift
@@ -5,7 +5,7 @@
 //  Created by Jack on 11/18/23.
 //
 
-import Foundation
+import SwiftUI
 
 /// NOTE: **Reading** FrameColor from the API is in title-case.
 /// **Writing** FrameColor to the API must be in lower-case.
@@ -42,4 +42,48 @@ enum FrameColor: String, Codable, CaseIterable, Identifiable, Equatable {
         .red, .pink, .orange, .yellow, .green, .teal, .blue, .purple, .brown, .black, .white,
         .bareMetal, .covered,
     ]
+
+    /// A `true` value Indicates that this color is displayed with a special View (such as a gradient)
+    /// or a `false` value indicates that this color can be converted to a ``SwiftUICore/Color``
+    var textured: Bool {
+        switch self {
+        case .bareMetal, .covered:
+            true
+        default:
+            false
+        }
+    }
+}
+
+extension FrameColor {
+    var color: Color? {
+        switch self {
+        case .bareMetal, .covered:
+            nil
+        case .black:
+            // slightly lighter than pure black for display
+            Color(white: 0.1)
+        case .blue:
+            .blue
+        case .brown:
+            .brown
+        case .green:
+            .green
+        case .orange:
+            .orange
+        case .pink:
+            .pink
+        case .purple:
+            .purple
+        case .red:
+            .red
+        case .teal:
+            .teal
+        case .white:
+            // Slightly darker than pure white for display
+            Color(white: 0.9)
+        case .yellow:
+            .yellow
+        }
+    }
 }

--- a/BikeIndex/Model/FrameColor.swift
+++ b/BikeIndex/Model/FrameColor.swift
@@ -87,3 +87,37 @@ extension FrameColor {
         }
     }
 }
+
+extension FrameColor {
+    var prettyColor: Color? {
+        switch self {
+        case .black:
+            Color(#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)) // #000
+        case .blue:
+            Color(#colorLiteral(red: 0.22, green: 0.431, blue: 0.824, alpha: 1)) // #386ed2
+        case .brown:
+            Color(#colorLiteral(red: 0.451, green: 0.29, blue: 0.133, alpha: 1)) // #734a22
+        case .green:
+            Color(#colorLiteral(red: 0.106, green: 0.631, blue: 0, alpha: 1)) // #1ba100<#code#>
+        case .orange:
+            Color(#colorLiteral(red: 1, green: 0.553, blue: 0.114, alpha: 1)) // #ff8d1d
+        case .pink:
+            Color(#colorLiteral(red: 1, green: 0.49, blue: 0.992, alpha: 1)) // #ff7dfd
+        case .purple:
+            Color(#colorLiteral(red: 0.655, green: 0.271, blue: 0.753, alpha: 1)) // #a745c0
+        case .red:
+            Color(#colorLiteral(red: 0.925, green: 0.075, blue: 0.075, alpha: 1)) // #ec1313
+        case .bareMetal:
+            // NOTE: normally nil!
+            Color(#colorLiteral(red: 0.69, green: 0.69, blue: 0.69, alpha: 1)) // #b0b0b0
+        case .covered:
+            nil
+        case .teal:
+            Color(#colorLiteral(red: 0.231, green: 0.929, blue: 0.906, alpha: 1)) // #3bede7
+        case .white:
+            Color(#colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)) // #fff
+        case .yellow:
+            Color(#colorLiteral(red: 1, green: 0.957, blue: 0.294, alpha: 1)) // #fff44b
+        }
+    }
+}

--- a/BikeIndex/Model/MockData.swift
+++ b/BikeIndex/Model/MockData.swift
@@ -59,8 +59,7 @@ struct MockData {
          "date_stolen": 1376719200,
          "description": "26 Giant Trance X  ",
          "frame_colors": [
-           "Green",
-           "Blue"
+           "Green"
          ],
          "frame_model": "Trance X",
          "id": 20348,

--- a/BikeIndex/View/BikeDetail/FrameColorsView.swift
+++ b/BikeIndex/View/BikeDetail/FrameColorsView.swift
@@ -36,39 +36,6 @@ struct FrameColorsView: View {
     }
 }
 
-extension FrameColor {
-    var color: Color? {
-        switch self {
-        case .bareMetal, .covered:
-            nil
-        case .black:
-            // slightly lighter than pure black for display
-            Color(white: 0.1)
-        case .blue:
-            .blue
-        case .brown:
-            .brown
-        case .green:
-            .green
-        case .orange:
-            .orange
-        case .pink:
-            .pink
-        case .purple:
-            .purple
-        case .red:
-            .red
-        case .teal:
-            .teal
-        case .white:
-            // Slightly darker than pure white for display
-            Color(white: 0.9)
-        case .yellow:
-            .yellow
-        }
-    }
-}
-
 extension Color {
     static let dimWhite = Color(white: 0.75)
     static let darkGray = Color(white: 0.25)

--- a/BikeIndex/View/Chip.swift
+++ b/BikeIndex/View/Chip.swift
@@ -60,6 +60,7 @@ struct Chip: View {
                 }
             // Color with value
             case (.roundedLabel, let value):
+                // TODO: Update with new FrameColor.prettyColor gradient/value
                 roundedLabel
                     .stroke(
                         value.color!.gradient,
@@ -89,24 +90,6 @@ struct Chip: View {
 
     private var circle: Circle {
         Circle()
-    }
-
-    static var bareMetalGradient: LinearGradient {
-        let base: [Color] = [
-            .darkGray,
-            .almostBlack,
-            .gray,
-            .almostBlack,
-            .darkGray,
-            .gray,
-            .almostBlack,
-        ]
-        let colors = Array(repeating: base, count: 3)
-            .flatMap { $0 }
-        return LinearGradient(
-            colors: colors,
-            startPoint: .bottomLeading,
-            endPoint: .topTrailing)
     }
 
     static var bareMetalAngularGradient: AngularGradient {

--- a/BikeIndex/View/Chip.swift
+++ b/BikeIndex/View/Chip.swift
@@ -60,16 +60,12 @@ struct Chip: View {
                 }
             // Color with value
             case (.roundedLabel, let value):
-                // TODO: Update with new FrameColor.prettyColor gradient/value
                 roundedLabel
-                    .stroke(
-                        value.color!.gradient,
-                        lineWidth: stroke
-                    )
+                    .stroke(Gradient(colors: value.gradientColors), lineWidth: stroke)
                     .fill(.background.tertiary)
             case (.circle, let value):
                 circle
-                    .fill(value.color!)
+                    .fill(Gradient(colors: value.gradientColors))
             }
 
             if style == .roundedLabel {

--- a/BikeIndex/View/MainContent/ColumnRectangle.swift
+++ b/BikeIndex/View/MainContent/ColumnRectangle.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+/// Special thanks to https://www.fivestars.blog/articles/swiftui-clipping/ for inspiration
 struct ColumnRectangle: Shape {
     /// The "position index" that the Shape receiving this `.clippedShape(BifurcatedRectangle())` **should** display within
     var column: Int

--- a/BikeIndex/View/MainContent/ColumnRectangle.swift
+++ b/BikeIndex/View/MainContent/ColumnRectangle.swift
@@ -1,0 +1,48 @@
+//
+//  ColumnRectangle.swift
+//  BikeIndex
+//
+//  Created by Jack on 1/30/26.
+//
+
+import SwiftUI
+
+struct ColumnRectangle: Shape {
+    /// The "position index" that the Shape receiving this `.clippedShape(BifurcatedRectangle())` **should** display within
+    var column: Int
+    var totalCount: Int
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.addRect(rect)
+
+        let colWidth = rect.width / CGFloat(totalCount)
+        for layoutColumn in 0..<totalCount where layoutColumn != column {
+            let clipRect = CGRect(
+                x: colWidth * CGFloat(layoutColumn),
+                y: rect.origin.y,
+                width: colWidth,
+                height: rect.height)
+            var clipPath = Path()
+            clipPath.addRect(clipRect)
+            path = path.subtracting(clipPath)
+        }
+
+        return path
+    }
+}
+
+#Preview {
+    VStack(spacing: 0) {
+        Rectangle()
+            .foregroundStyle(.red)
+            .clipShape(ColumnRectangle(column: 0, totalCount: 3))
+        Rectangle()
+            .foregroundStyle(.red)
+            .clipShape(ColumnRectangle(column: 1, totalCount: 3))
+        Rectangle()
+            .foregroundStyle(.red)
+            .clipShape(ColumnRectangle(column: 2, totalCount: 3))
+    }
+    .background(.yellow)
+}

--- a/BikeIndex/View/MainContent/ContentBikeButton.swift
+++ b/BikeIndex/View/MainContent/ContentBikeButton.swift
@@ -43,7 +43,7 @@ struct ContentBikeButtonView: View {
                         maxHeight: .infinity
                     )
                     .aspectRatio(1.0, contentMode: .fit)
-                    .clipShape(RoundedRectangle(cornerRadius: 24))
+//                    .clipShape(RoundedRectangle(cornerRadius: 24))
 
                     HStack {
                         Text(bike.displayTitle)

--- a/BikeIndex/View/MainContent/ContentBikeButton.swift
+++ b/BikeIndex/View/MainContent/ContentBikeButton.swift
@@ -27,17 +27,15 @@ struct ContentBikeButtonView: View {
         if let bike = bikeQuery.first, bikeQuery.count == 1 {
             NavigationLink(value: bike.identifier) {
                 VStack {
-                    ZStack {
-                        // TODO: Current: CachedAsyncImage { success=image | placeholder}
-                        // TODO: Make: ButtonBackground { CachedAsyncImage | ContentUnavailable }
-                        CachedAsyncImage(url: bike.largeImage) { image in
-                            image
-                                .resizable()
-                                .scaledToFill()
-                        } placeholder: {
-                            ContentButtonBorder(frameColors: bike.frameColors)
-                        }
+                    CachedAsyncImage(url: bike.largeImage) { image in
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    } placeholder: {
+                        FrameColorBackground(frameColors: bike.frameColors)
                     }
+                    .tint(.primary)
+                    .foregroundStyle(.primary)
                     .frame(
                         minWidth: 100,
                         maxWidth: .infinity,

--- a/BikeIndex/View/MainContent/ContentBikeButton.swift
+++ b/BikeIndex/View/MainContent/ContentBikeButton.swift
@@ -21,6 +21,8 @@ struct ContentBikeButtonView: View {
             })
     }
 
+    private let stroke = 4.0
+
     var body: some View {
         if let bike = bikeQuery.first, bikeQuery.count == 1 {
             NavigationLink(value: bike.identifier) {
@@ -41,9 +43,42 @@ struct ContentBikeButtonView: View {
                                     minHeight: 100,
                                     maxHeight: .infinity
                                 )
-                                .tint(Color.white)
-                                .background(
-                                    Color.accentColor, in: RoundedRectangle(cornerRadius: 24))
+                                .tint(Color.secondary)
+//                                .background(
+//                                    bike.frameColorPrimary.color ?? .accent,
+//                                    in: RoundedRectangle(cornerRadius: 24))
+                                .background {
+                                    switch bike.frameColorPrimary {
+                                    // Bare Metal
+                                    case .bareMetal:
+                                        RoundedRectangle(cornerRadius: 24)
+                                            .stroke(
+                                                Chip.bareMetalAngularGradient,
+                                                lineWidth: stroke / 2)
+                                    // Covered
+                                    case .covered:
+                                        if #available(iOS 18.0, *) {
+                                            RoundedRectangle(cornerRadius: 24)
+                                                .fill(Chip.rainbow18)
+//                                                .strokeBorder(
+//                                                    Chip.rainbow18,
+//                                                    lineWidth: stroke / 2)
+                                        } else {
+                                            RoundedRectangle(cornerRadius: 24)
+                                                .stroke(
+                                                    Chip.rainbow17,
+                                                    lineWidth: stroke / 2)
+                                        }
+                                    // Color with value
+                                    case let value:
+                                        RoundedRectangle(cornerRadius: 24)
+                                            .stroke(
+                                                value.color!.gradient,
+                                                lineWidth: stroke
+                                            )
+                                            .fill(.background.tertiary)
+                                    }
+                                }
 
                         }
                     }
@@ -72,7 +107,7 @@ struct ContentBikeButtonView: View {
 
     let sampleBike1 = Bike(
         identifier: 1,
-        primaryColor: FrameColor.bareMetal,
+        primaryColor: FrameColor.black,
         manufacturerName: "Jamis",
         typeOfCycle: .bike,
         typeOfPropulsion: .footPedal,
@@ -88,7 +123,7 @@ struct ContentBikeButtonView: View {
 
     let sampleBike2 = Bike(
         identifier: 2,
-        primaryColor: FrameColor.bareMetal,
+        primaryColor: FrameColor.white,
         manufacturerName: "Wide",
         typeOfCycle: .bike,
         typeOfPropulsion: .footPedal,
@@ -120,7 +155,7 @@ struct ContentBikeButtonView: View {
 
     let sampleBike4 = Bike(
         identifier: 4,
-        primaryColor: FrameColor.bareMetal,
+        primaryColor: FrameColor.blue,
         manufacturerName: "Empty",
         typeOfCycle: BicycleType.bike,
         typeOfPropulsion: .footPedal,

--- a/BikeIndex/View/MainContent/ContentBikeButton.swift
+++ b/BikeIndex/View/MainContent/ContentBikeButton.swift
@@ -33,53 +33,7 @@ struct ContentBikeButtonView: View {
                                 .resizable()
                                 .scaledToFill()
                         } placeholder: {
-                            Image(systemName: "bicycle")
-                                .resizable()
-                                .scaledToFit()
-                                .padding()
-                                .frame(
-                                    minWidth: 100,
-                                    maxWidth: .infinity,
-                                    minHeight: 100,
-                                    maxHeight: .infinity
-                                )
-                                .tint(Color.secondary)
-//                                .background(
-//                                    bike.frameColorPrimary.color ?? .accent,
-//                                    in: RoundedRectangle(cornerRadius: 24))
-                                .background {
-                                    switch bike.frameColorPrimary {
-                                    // Bare Metal
-                                    case .bareMetal:
-                                        RoundedRectangle(cornerRadius: 24)
-                                            .stroke(
-                                                Chip.bareMetalAngularGradient,
-                                                lineWidth: stroke / 2)
-                                    // Covered
-                                    case .covered:
-                                        if #available(iOS 18.0, *) {
-                                            RoundedRectangle(cornerRadius: 24)
-                                                .fill(Chip.rainbow18)
-//                                                .strokeBorder(
-//                                                    Chip.rainbow18,
-//                                                    lineWidth: stroke / 2)
-                                        } else {
-                                            RoundedRectangle(cornerRadius: 24)
-                                                .stroke(
-                                                    Chip.rainbow17,
-                                                    lineWidth: stroke / 2)
-                                        }
-                                    // Color with value
-                                    case let value:
-                                        RoundedRectangle(cornerRadius: 24)
-                                            .stroke(
-                                                value.color!.gradient,
-                                                lineWidth: stroke
-                                            )
-                                            .fill(.background.tertiary)
-                                    }
-                                }
-
+                            ContentButtonBorder(frameColors: bike.frameColors)
                         }
                     }
                     .frame(
@@ -124,6 +78,7 @@ struct ContentBikeButtonView: View {
     let sampleBike2 = Bike(
         identifier: 2,
         primaryColor: FrameColor.white,
+        secondaryColor: .blue,
         manufacturerName: "Wide",
         typeOfCycle: .bike,
         typeOfPropulsion: .footPedal,

--- a/BikeIndex/View/MainContent/ContentBikeButton.swift
+++ b/BikeIndex/View/MainContent/ContentBikeButton.swift
@@ -28,6 +28,8 @@ struct ContentBikeButtonView: View {
             NavigationLink(value: bike.identifier) {
                 VStack {
                     ZStack {
+                        // TODO: Current: CachedAsyncImage { success=image | placeholder}
+                        // TODO: Make: ButtonBackground { CachedAsyncImage | ContentUnavailable }
                         CachedAsyncImage(url: bike.largeImage) { image in
                             image
                                 .resizable()
@@ -43,7 +45,7 @@ struct ContentBikeButtonView: View {
                         maxHeight: .infinity
                     )
                     .aspectRatio(1.0, contentMode: .fit)
-//                    .clipShape(RoundedRectangle(cornerRadius: 24))
+                    .clipShape(RoundedRectangle(cornerRadius: 24))
 
                     HStack {
                         Text(bike.displayTitle)

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -19,28 +19,22 @@ struct ContentButtonBorder: View {
             GeometryReader { geo in
                 // Textured FrameColor background IF applicable
                 ZStack {
-                    let texturedColors = frameColors.filter { $0.textured }
                     let totalCount = frameColors.count
-                    ForEach(texturedColors, id: \.id) { frame in
+                    ForEach(Array(frameColors.enumerated()), id: \.element.id) { (offset, frame) in
                         switch frame {
                         case .bareMetal:
-//                            Rectangle()
                             Chip.bareMetalAngularGradient
                                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-//                                .overlay {
-//                                    Chip.bareMetalAngularGradient
-//                                }
-                                .clipShape(ColumnRectangle(column: 2, totalCount: totalCount))
-
-//                                .containerRelativeFrame(.horizontal, count: frameColors.count, spacing: 0)
+                                .clipShape(ColumnRectangle(column: offset, totalCount: totalCount))
                         case .covered:
                             // Covered
                             if #available(iOS 18.0, *) {
                                 Chip.rainbow18
                                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-//                                    .clipShape(BifurcatedRectangle(totalCount: totalCount))
+                                    .clipShape(ColumnRectangle(column: offset, totalCount: totalCount))
                             } else {
                                 Chip.rainbow17
+                                    .clipShape(ColumnRectangle(column: offset, totalCount: totalCount))
                             }
                         default:
                             EmptyView()
@@ -50,9 +44,7 @@ struct ContentButtonBorder: View {
                 .aspectRatio(1.0, contentMode: .fit)
                 .clipped()
 
-            /*
-            // Foreground stripes of solid frame colors, with cutouts for textured background
-
+                // Foreground stripes of solid frame colors, with cutouts for textured background
                 HStack(spacing: 0) {
                     let count = CGFloat(frameColors.count)
                     ForEach(.constant(frameColors), id: \.id) { frame in
@@ -76,7 +68,6 @@ struct ContentButtonBorder: View {
                         }
                     }
                 }
-             */
             }
             .aspectRatio(1.0, contentMode: .fit)
         }
@@ -102,9 +93,9 @@ struct ContentButtonBorder: View {
     ScrollView {
         ProportionalLazyVGrid {
             ContentButtonBorder(frameColors: [.blue, .red, .bareMetal])
-//            ContentButtonBorder(frameColors: [.red, .orange, .yellow])
-//            ContentButtonBorder(frameColors: [.white, .black, .covered])
-            ContentButtonBorder(frameColors: [.bareMetal, .white, .covered])
+            ContentButtonBorder(frameColors: [.red, .orange, .yellow])
+            ContentButtonBorder(frameColors: [.covered, .brown, .black])
+            ContentButtonBorder(frameColors: [.bareMetal, .covered])
             if #available(iOS 18, *) {
                 Chip.rainbow18
             } else {

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -11,32 +11,22 @@ struct ContentButtonBorder: View {
     var frameColors: [FrameColor]
 
     var body: some View {
-        Image(systemName: "bicycle")
-            .resizable()
-            .scaledToFit()
-            .padding()
+        borderGradient
             .frame(
                 minWidth: 100,
                 maxWidth: .infinity,
                 minHeight: 100,
                 maxHeight: .infinity
             )
-//            .clipShape(RoundedRectangle(cornerRadius: 24))
-
-            .tint(.secondary)
-            .foregroundStyle(.primary)
-            .shadow(color: .accent, radius: 4)
-
-//            .buttonBorderShape(.roundedRectangle)
-//            .clipShape(RoundedRectangle(cornerRadius: 24))
-
-//            .border(borderGradient,
-//                    width: 10)
-
-            .clipShape(RoundedRectangle(cornerRadius: 24))
-
-            .background {
-                borderGradient
+            .cornerRadius(24)
+            .overlay {
+                Image(systemName: "bicycle")
+                    .resizable()
+                    .scaledToFit()
+                    .padding()
+                    .tint(.secondary)
+                    .foregroundStyle(.primary)
+                    .shadow(color: .accent, radius: 1)
             }
     }
 

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -1,0 +1,58 @@
+//
+//  ContentButtonBorder.swift
+//  BikeIndex
+//
+//  Created by Jack on 1/22/26.
+//
+
+import SwiftUI
+
+struct ContentButtonBorder: View {
+    var frameColors: [FrameColor]
+
+    var body: some View {
+        Image(systemName: "bicycle")
+            .resizable()
+            .scaledToFit()
+            .padding()
+            .frame(
+                minWidth: 100,
+                maxWidth: .infinity,
+                minHeight: 100,
+                maxHeight: .infinity
+            )
+//            .clipShape(RoundedRectangle(cornerRadius: 24))
+
+            .tint(.secondary)
+            .foregroundStyle(.primary)
+            .shadow(color: .accent, radius: 4)
+
+//            .buttonBorderShape(.roundedRectangle)
+//            .clipShape(RoundedRectangle(cornerRadius: 24))
+
+//            .border(borderGradient,
+//                    width: 10)
+
+            .clipShape(RoundedRectangle(cornerRadius: 24))
+
+            .background {
+                borderGradient
+            }
+    }
+
+    var borderGradient: LinearGradient {
+        LinearGradient(colors: frameColors.compactMap(\.color), startPoint: .topLeading, endPoint: .bottomTrailing)
+    }
+}
+
+#Preview {
+    ScrollView {
+        ProportionalLazyVGrid {
+            ContentButtonBorder(frameColors: [.bareMetal, .blue, .red])
+            ContentButtonBorder(frameColors: [.red, .orange, .yellow])
+            ContentButtonBorder(frameColors: [.covered, .white, .black])
+            ContentButtonBorder(frameColors: [.red, .pink, .white])
+            ContentButtonBorder(frameColors: [.green, .blue, .purple])
+        }
+    }
+}

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -13,41 +13,54 @@ struct ContentButtonBorder: View {
     var frameColors: [FrameColor]
 
     var body: some View {
-        borderGradient
-            .cornerRadius(24)
-            .overlay {
-                Image(systemName: "bicycle")
-                    .resizable()
-                    .scaledToFit()
-                    .padding()
-                    .tint(.secondary)
-                    .foregroundStyle(.primary)
-                    .shadow(color: .accent, radius: 1)
+        HStack {
+            ForEach(.constant(frameColors), id: \.id) { frame in
 
-//                    .aspectRatio(1.0, contentMode: .fit)
-//                    .background {
-//                        RoundedRectangle(cornerRadius: 24)
-//                    }
+                switch frame.wrappedValue {
+                    // Bare Metal
+                case .bareMetal:
+                    Chip.bareMetalAngularGradient
+                    // Covered
+                case .covered:
+                    if #available(iOS 18.0, *) {
+                        Chip.rainbow18
+                    } else {
+                        Chip.rainbow17
+                    }
+                    // Color with value
+                case (let value):
+                    if let color = value.color {
+                        // Cannot convert value of type 'Color?' to expected element type 'Array<Color>.ArrayLiteralElement' (aka 'Color')
+                        LinearGradient(colors: [color], startPoint: .leading, endPoint: .trailing)
+                    } else {
+                        Text("Inconsident FrameColor usage")
+                    }
+                }
             }
-            .frame(
-                minWidth: 100,
-                maxWidth: .infinity,
-                minHeight: 100,
-                maxHeight: .infinity
-            )
-            .aspectRatio(1.0, contentMode: .fit)
-    }
-
-    var borderGradient: AngularGradient {
-//        LinearGradient(colors: frameColors.compactMap(\.color), startPoint: .topLeading, endPoint: .bottomTrailing)
-
-        let colors = frameColors.compactMap(\.color)
-        let count = colors.count
-        let stops = colors.enumerated().map { (offset, color) in
-            Gradient.Stop(color: color, location: CGFloat(offset / count))
         }
-        return AngularGradient(stops: stops, center: .center, angle: .zero)
-//        return AngularGradient(colors: colors, center: .center, startAngle: .zero, endAngle: .degrees(180))
+
+        .cornerRadius(24)
+        .overlay {
+            Image(systemName: "bicycle")
+                .resizable()
+                .scaledToFit()
+                .padding()
+                .tint(.secondary)
+                .foregroundStyle(.primary)
+                .shadow(color: Color(uiColor: .systemBackground), radius: 5)
+
+            //                    .aspectRatio(1.0, contentMode: .fit)
+            //                    .background {
+            //                        RoundedRectangle(cornerRadius: 24)
+            //                    }
+        }
+        .frame(
+            minWidth: 100,
+            maxWidth: .infinity,
+            minHeight: 100,
+            maxHeight: .infinity
+        )
+        .aspectRatio(1.0, contentMode: .fit)
     }
 }
 

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -12,12 +12,6 @@ struct ContentButtonBorder: View {
 
     var body: some View {
         borderGradient
-            .frame(
-                minWidth: 100,
-                maxWidth: .infinity,
-                minHeight: 100,
-                maxHeight: .infinity
-            )
             .cornerRadius(24)
             .overlay {
                 Image(systemName: "bicycle")
@@ -27,11 +21,31 @@ struct ContentButtonBorder: View {
                     .tint(.secondary)
                     .foregroundStyle(.primary)
                     .shadow(color: .accent, radius: 1)
+
+//                    .aspectRatio(1.0, contentMode: .fit)
+//                    .background {
+//                        RoundedRectangle(cornerRadius: 24)
+//                    }
             }
+            .frame(
+                minWidth: 100,
+                maxWidth: .infinity,
+                minHeight: 100,
+                maxHeight: .infinity
+            )
+            .aspectRatio(1.0, contentMode: .fit)
     }
 
-    var borderGradient: LinearGradient {
-        LinearGradient(colors: frameColors.compactMap(\.color), startPoint: .topLeading, endPoint: .bottomTrailing)
+    var borderGradient: AngularGradient {
+//        LinearGradient(colors: frameColors.compactMap(\.color), startPoint: .topLeading, endPoint: .bottomTrailing)
+
+        let colors = frameColors.compactMap(\.color)
+        let count = colors.count
+        let stops = colors.enumerated().map { (offset, color) in
+            Gradient.Stop(color: color, location: CGFloat(offset / count))
+        }
+        return AngularGradient(stops: stops, center: .center, angle: .zero)
+//        return AngularGradient(colors: colors, center: .center, startAngle: .zero, endAngle: .degrees(180))
     }
 }
 
@@ -41,7 +55,7 @@ struct ContentButtonBorder: View {
             ContentButtonBorder(frameColors: [.bareMetal, .blue, .red])
             ContentButtonBorder(frameColors: [.red, .orange, .yellow])
             ContentButtonBorder(frameColors: [.covered, .white, .black])
-            ContentButtonBorder(frameColors: [.red, .pink, .white])
+            ContentButtonBorder(frameColors: [.white])
             ContentButtonBorder(frameColors: [.green, .blue, .purple])
         }
     }

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+@available(*, deprecated, message: "TODO: Rename, this is the wrong name.")
+// TODO: Use vertical stripes for simplicity and clarity
 struct ContentButtonBorder: View {
     var frameColors: [FrameColor]
 

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 @available(*, deprecated, message: "TODO: Rename, this is the wrong name.")
-// TODO: Use vertical stripes for simplicity and clarity
+// ✅ DONE: Use vertical stripes for simplicity and clarity
+// TODO: Add public bike image to the Preview and check with images too
 struct ContentButtonBorder: View {
     var frameColors: [FrameColor]
 

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -31,10 +31,12 @@ struct ContentButtonBorder: View {
                             if #available(iOS 18.0, *) {
                                 Chip.rainbow18
                                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                    .clipShape(ColumnRectangle(column: offset, totalCount: totalCount))
+                                    .clipShape(
+                                        ColumnRectangle(column: offset, totalCount: totalCount))
                             } else {
                                 Chip.rainbow17
-                                    .clipShape(ColumnRectangle(column: offset, totalCount: totalCount))
+                                    .clipShape(
+                                        ColumnRectangle(column: offset, totalCount: totalCount))
                             }
                         default:
                             EmptyView()
@@ -59,9 +61,11 @@ struct ContentButtonBorder: View {
                             // Color with value
                             if let color = value.color {
                                 // TODO: Fix color.gradient here
-                                LinearGradient(colors: [color], startPoint: .leading, endPoint: .trailing)
-                                    .zIndex(100)
-                                    .frame(width: geo.size.width / count)
+                                LinearGradient(
+                                    colors: [color], startPoint: .leading, endPoint: .trailing
+                                )
+                                .zIndex(100)
+                                .frame(width: geo.size.width / count)
                             } else {
                                 Text("Inconsident FrameColor usage")
                             }
@@ -123,10 +127,11 @@ struct ColumnRectangle: Shape {
 
         let colWidth = rect.width / CGFloat(totalCount)
         for layoutColumn in 0..<totalCount where layoutColumn != column {
-            let clipRect = CGRect(x: colWidth * CGFloat(layoutColumn),
-                                  y: rect.origin.y,
-                                  width: colWidth,
-                                  height: rect.height)
+            let clipRect = CGRect(
+                x: colWidth * CGFloat(layoutColumn),
+                y: rect.origin.y,
+                width: colWidth,
+                height: rect.height)
             var clipPath = Path()
             clipPath.addRect(clipRect)
             path = path.subtracting(clipPath)

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -18,17 +18,17 @@ struct ContentButtonBorder: View {
             ForEach(.constant(frameColors), id: \.id) { frame in
 
                 switch frame.wrappedValue {
-                    // Bare Metal
+                // Bare Metal
                 case .bareMetal:
                     Chip.bareMetalAngularGradient
-                    // Covered
+                // Covered
                 case .covered:
                     if #available(iOS 18.0, *) {
                         Chip.rainbow18
                     } else {
                         Chip.rainbow17
                     }
-                    // Color with value
+                // Color with value
                 case (let value):
                     if let color = value.color {
                         // Cannot convert value of type 'Color?' to expected element type 'Array<Color>.ArrayLiteralElement' (aka 'Color')

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -15,45 +15,67 @@ struct ContentButtonBorder: View {
     var frameColors: [FrameColor]
 
     var body: some View {
-        GeometryReader { geo in
+        ZStack {
+            // Textured FrameColor background IF applicable
             HStack(spacing: 0) {
                 ForEach(.constant(frameColors), id: \.id) { frame in
                     switch frame.wrappedValue {
                     case .bareMetal:
-                        // Bare Metal
-                        Rectangle()
-                            .overlay {
-                                Chip.bareMetalAngularGradient
-                                    .frame(width: geo.size.width, height: geo.size.height)
-                                    .clipped()
-                                    .zIndex(-100)
-                            }
+                        Rectangle().overlay {
+                            Chip.bareMetalAngularGradient
+                        }
                     case .covered:
                         // Covered
                         if #available(iOS 18.0, *) {
-                            Rectangle()
-                                .overlay {
-                                    Chip.rainbow18
-                                        .frame(width: geo.size.width, height: geo.size.height)
-                                        .onAppear { print("@@", geo.size) }
-                                }
-                                .clipped()
+                            Rectangle().overlay {
+                                Chip.rainbow18
+                            }
                         } else {
                             Chip.rainbow17
                         }
-                    case (let value):
-                        // Color with value
-                        if let color = value.color {
-                            // TODO: Fix color.gradient here
-                            LinearGradient(colors: [color], startPoint: .leading, endPoint: .trailing)
-                                .zIndex(100)
-                        } else {
-                            Text("Inconsident FrameColor usage")
+                    default:
+                        EmptyView()
+                    }
+                }
+                
+            }
+            .aspectRatio(1.0, contentMode: .fit)
+            .clipped()
+
+            // Foreground stripes of solid frame colors, with cutouts for textured background
+            GeometryReader { geo in
+                HStack(spacing: 0) {
+                    let count = CGFloat(frameColors.count)
+                    ForEach(.constant(frameColors), id: \.id) { frame in
+                        switch frame.wrappedValue {
+                        case .bareMetal:
+                            Spacer()
+                                .frame(width: geo.size.width / count)
+                        case .covered:
+                            Spacer()
+                                .frame(width: geo.size.width / count)
+                        case (let value):
+                            // Color with value
+                            if let color = value.color {
+                                // TODO: Fix color.gradient here
+                                LinearGradient(colors: [color], startPoint: .leading, endPoint: .trailing)
+                                    .zIndex(100)
+                                    .frame(width: geo.size.width / count)
+                            } else {
+                                Text("Inconsident FrameColor usage")
+                            }
                         }
                     }
                 }
             }
+            .aspectRatio(1.0, contentMode: .fit)
+
         }
+        .frame(
+            minWidth: 100,
+            minHeight: 100
+        )
+        .aspectRatio(1.0, contentMode: .fit)
         .cornerRadius(24)
         .overlay {
             Image(systemName: "bicycle")
@@ -63,19 +85,7 @@ struct ContentButtonBorder: View {
                 .tint(.secondary)
                 .foregroundStyle(.primary)
                 .shadow(color: Color(uiColor: .systemBackground), radius: 5)
-
-            //                    .aspectRatio(1.0, contentMode: .fit)
-            //                    .background {
-            //                        RoundedRectangle(cornerRadius: 24)
-            //                    }
         }
-        .frame(
-            minWidth: 100,
-            maxWidth: .infinity,
-            minHeight: 100,
-            maxHeight: .infinity
-        )
-        .aspectRatio(1.0, contentMode: .fit)
     }
 }
 
@@ -85,13 +95,19 @@ struct ContentButtonBorder: View {
             ContentButtonBorder(frameColors: [.blue, .red, .bareMetal])
             ContentButtonBorder(frameColors: [.red, .orange, .yellow])
             ContentButtonBorder(frameColors: [.white, .black, .covered])
-            ContentButtonBorder(frameColors: [.white])
+            ContentButtonBorder(frameColors: [.bareMetal, .white, .covered])
             if #available(iOS 18, *) {
                 Chip.rainbow18
             } else {
                 Chip.rainbow17
             }
             ContentButtonBorder(frameColors: [.green, .blue, .purple])
+            Chip.bareMetalAngularGradient
+                .frame(
+                    minWidth: 100,
+                    minHeight: 100,
+                )
+                .aspectRatio(1.0, contentMode: .fit)
         }
     }
 }

--- a/BikeIndex/View/MainContent/ContentButtonBorder.swift
+++ b/BikeIndex/View/MainContent/ContentButtonBorder.swift
@@ -10,36 +10,50 @@ import SwiftUI
 @available(*, deprecated, message: "TODO: Rename, this is the wrong name.")
 // ✅ DONE: Use vertical stripes for simplicity and clarity
 // TODO: Add public bike image to the Preview and check with images too
+// TODO: Rely on https://bikeindex.org/api/v3/selections/colors
 struct ContentButtonBorder: View {
     var frameColors: [FrameColor]
 
     var body: some View {
-        HStack {
-            ForEach(.constant(frameColors), id: \.id) { frame in
-
-                switch frame.wrappedValue {
-                // Bare Metal
-                case .bareMetal:
-                    Chip.bareMetalAngularGradient
-                // Covered
-                case .covered:
-                    if #available(iOS 18.0, *) {
-                        Chip.rainbow18
-                    } else {
-                        Chip.rainbow17
-                    }
-                // Color with value
-                case (let value):
-                    if let color = value.color {
-                        // Cannot convert value of type 'Color?' to expected element type 'Array<Color>.ArrayLiteralElement' (aka 'Color')
-                        LinearGradient(colors: [color], startPoint: .leading, endPoint: .trailing)
-                    } else {
-                        Text("Inconsident FrameColor usage")
+        GeometryReader { geo in
+            HStack(spacing: 0) {
+                ForEach(.constant(frameColors), id: \.id) { frame in
+                    switch frame.wrappedValue {
+                    case .bareMetal:
+                        // Bare Metal
+                        Rectangle()
+                            .overlay {
+                                Chip.bareMetalAngularGradient
+                                    .frame(width: geo.size.width, height: geo.size.height)
+                                    .clipped()
+                                    .zIndex(-100)
+                            }
+                    case .covered:
+                        // Covered
+                        if #available(iOS 18.0, *) {
+                            Rectangle()
+                                .overlay {
+                                    Chip.rainbow18
+                                        .frame(width: geo.size.width, height: geo.size.height)
+                                        .onAppear { print("@@", geo.size) }
+                                }
+                                .clipped()
+                        } else {
+                            Chip.rainbow17
+                        }
+                    case (let value):
+                        // Color with value
+                        if let color = value.color {
+                            // TODO: Fix color.gradient here
+                            LinearGradient(colors: [color], startPoint: .leading, endPoint: .trailing)
+                                .zIndex(100)
+                        } else {
+                            Text("Inconsident FrameColor usage")
+                        }
                     }
                 }
             }
         }
-
         .cornerRadius(24)
         .overlay {
             Image(systemName: "bicycle")
@@ -68,10 +82,15 @@ struct ContentButtonBorder: View {
 #Preview {
     ScrollView {
         ProportionalLazyVGrid {
-            ContentButtonBorder(frameColors: [.bareMetal, .blue, .red])
+            ContentButtonBorder(frameColors: [.blue, .red, .bareMetal])
             ContentButtonBorder(frameColors: [.red, .orange, .yellow])
-            ContentButtonBorder(frameColors: [.covered, .white, .black])
+            ContentButtonBorder(frameColors: [.white, .black, .covered])
             ContentButtonBorder(frameColors: [.white])
+            if #available(iOS 18, *) {
+                Chip.rainbow18
+            } else {
+                Chip.rainbow17
+            }
             ContentButtonBorder(frameColors: [.green, .blue, .purple])
         }
     }

--- a/BikeIndex/View/MainContent/FrameColorBackground.swift
+++ b/BikeIndex/View/MainContent/FrameColorBackground.swift
@@ -1,5 +1,5 @@
 //
-//  ContentButtonBorder.swift
+//  FrameColorBackground.swift
 //  BikeIndex
 //
 //  Created by Jack on 1/22/26.
@@ -7,11 +7,9 @@
 
 import SwiftUI
 
-@available(*, deprecated, message: "TODO: Rename, this is the wrong name.")
 // ✅ DONE: Use vertical stripes for simplicity and clarity
-// TODO: Add public bike image to the Preview and check with images too
 // TODO: Rely on https://bikeindex.org/api/v3/selections/colors
-struct ContentButtonBorder: View {
+struct FrameColorBackground: View {
     var frameColors: [FrameColor]
 
     var body: some View {
@@ -86,8 +84,6 @@ struct ContentButtonBorder: View {
                 .resizable()
                 .scaledToFit()
                 .padding()
-                .tint(.secondary)
-                .foregroundStyle(.primary)
                 .shadow(color: Color(uiColor: .systemBackground), radius: 5)
         }
     }
@@ -96,16 +92,16 @@ struct ContentButtonBorder: View {
 #Preview {
     ScrollView {
         ProportionalLazyVGrid {
-            ContentButtonBorder(frameColors: [.blue, .red, .bareMetal])
-            ContentButtonBorder(frameColors: [.red, .orange, .yellow])
-            ContentButtonBorder(frameColors: [.covered, .brown, .black])
-            ContentButtonBorder(frameColors: [.bareMetal, .covered])
+            FrameColorBackground(frameColors: [.blue, .red, .bareMetal])
+            FrameColorBackground(frameColors: [.red, .orange, .yellow])
+            FrameColorBackground(frameColors: [.covered, .brown, .black])
+            FrameColorBackground(frameColors: [.bareMetal, .covered])
             if #available(iOS 18, *) {
                 Chip.rainbow18
             } else {
                 Chip.rainbow17
             }
-            ContentButtonBorder(frameColors: [.green, .blue, .purple])
+            FrameColorBackground(frameColors: [.green, .blue, .purple])
             Chip.bareMetalAngularGradient
                 .frame(
                     minWidth: 100,
@@ -114,45 +110,4 @@ struct ContentButtonBorder: View {
                 .aspectRatio(1.0, contentMode: .fit)
         }
     }
-}
-
-struct ColumnRectangle: Shape {
-    /// The "position index" that the Shape receiving this `.clippedShape(BifurcatedRectangle())` **should** display within
-    var column: Int
-    var totalCount: Int
-
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        path.addRect(rect)
-
-        let colWidth = rect.width / CGFloat(totalCount)
-        for layoutColumn in 0..<totalCount where layoutColumn != column {
-            let clipRect = CGRect(
-                x: colWidth * CGFloat(layoutColumn),
-                y: rect.origin.y,
-                width: colWidth,
-                height: rect.height)
-            var clipPath = Path()
-            clipPath.addRect(clipRect)
-            path = path.subtracting(clipPath)
-            print("Evaluating layout column", layoutColumn, clipRect)
-        }
-
-        return path
-    }
-}
-
-#Preview {
-    VStack(spacing: 0) {
-        Rectangle()
-            .foregroundStyle(.red)
-            .clipShape(ColumnRectangle(column: 0, totalCount: 3))
-        Rectangle()
-            .foregroundStyle(.red)
-            .clipShape(ColumnRectangle(column: 1, totalCount: 3))
-        Rectangle()
-            .foregroundStyle(.red)
-            .clipShape(ColumnRectangle(column: 2, totalCount: 3))
-    }
-    .background(.yellow)
 }

--- a/BikeIndex/View/MainContent/FrameColorBackground.swift
+++ b/BikeIndex/View/MainContent/FrameColorBackground.swift
@@ -56,10 +56,10 @@ struct FrameColorBackground: View {
                                 .frame(width: geo.size.width / count)
                         case (let value):
                             // Color with value
-                            if let color = value.color {
+                            if let color = value.color, let secondColor = value.prettyColor {
                                 // TODO: Fix color.gradient here
                                 LinearGradient(
-                                    colors: [color], startPoint: .leading, endPoint: .trailing
+                                    colors: [color, secondColor], startPoint: .top, endPoint: .bottom
                                 )
                                 .zIndex(100)
                                 .frame(width: geo.size.width / count)
@@ -91,10 +91,10 @@ struct FrameColorBackground: View {
 #Preview {
     ScrollView {
         ProportionalLazyVGrid {
-            FrameColorBackground(frameColors: [.blue, .red, .bareMetal])
+            FrameColorBackground(frameColors: [.teal, .red, .bareMetal])
             FrameColorBackground(frameColors: [.red, .orange, .yellow])
             FrameColorBackground(frameColors: [.covered, .brown, .black])
-            FrameColorBackground(frameColors: [.bareMetal, .covered])
+            FrameColorBackground(frameColors: [.bareMetal, .white, .covered])
             if #available(iOS 18, *) {
                 Chip.rainbow18
             } else {

--- a/BikeIndex/View/MainContent/FrameColorBackground.swift
+++ b/BikeIndex/View/MainContent/FrameColorBackground.swift
@@ -59,7 +59,8 @@ struct FrameColorBackground: View {
                             if let color = value.color, let secondColor = value.prettyColor {
                                 // TODO: Fix color.gradient here
                                 LinearGradient(
-                                    colors: [color, secondColor], startPoint: .top, endPoint: .bottom
+                                    colors: [color, secondColor], startPoint: .top,
+                                    endPoint: .bottom
                                 )
                                 .zIndex(100)
                                 .frame(width: geo.size.width / count)

--- a/BikeIndex/View/MainContent/FrameColorBackground.swift
+++ b/BikeIndex/View/MainContent/FrameColorBackground.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-// ✅ DONE: Use vertical stripes for simplicity and clarity
 // TODO: Rely on https://bikeindex.org/api/v3/selections/colors
 struct FrameColorBackground: View {
     var frameColors: [FrameColor]

--- a/BikeIndex/View/MainContent/FrameColorBackground.swift
+++ b/BikeIndex/View/MainContent/FrameColorBackground.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-// TODO: Rely on https://bikeindex.org/api/v3/selections/colors
 struct FrameColorBackground: View {
     var frameColors: [FrameColor]
 
@@ -45,28 +44,22 @@ struct FrameColorBackground: View {
 
                 // Foreground stripes of solid frame colors, with cutouts for textured background
                 HStack(spacing: 0) {
-                    let count = CGFloat(frameColors.count)
+                    let columnWidth = geo.size.width / CGFloat(frameColors.count)
                     ForEach(.constant(frameColors), id: \.id) { frame in
                         switch frame.wrappedValue {
                         case .bareMetal:
                             Spacer()
-                                .frame(width: geo.size.width / count)
+                                .frame(width: columnWidth)
                         case .covered:
                             Spacer()
-                                .frame(width: geo.size.width / count)
+                                .frame(width: columnWidth)
                         case (let value):
-                            // Color with value
-                            if let color = value.color, let secondColor = value.prettyColor {
-                                // TODO: Fix color.gradient here
-                                LinearGradient(
-                                    colors: [color, secondColor], startPoint: .top,
-                                    endPoint: .bottom
-                                )
-                                .zIndex(100)
-                                .frame(width: geo.size.width / count)
-                            } else {
-                                Text("Inconsident FrameColor usage")
-                            }
+                            LinearGradient(
+                                colors: value.gradientColors, startPoint: .top,
+                                endPoint: .bottom
+                            )
+                            .zIndex(100)
+                            .frame(width: columnWidth)
                         }
                     }
                 }

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -161,6 +161,7 @@ struct MainContentPage: View {
                 let manufacturers = [
                     "Giant", "Specialized", "Jamis", "Giant", "Specialized", "Jamis",
                 ]
+                let colors: [FrameColor] = [.bareMetal, .covered, .white, .red, .black, .yellow]
 
                 for (index, status) in statuses.enumerated() {
                     let output = try JSONDecoder().decode(
@@ -172,6 +173,7 @@ struct MainContentPage: View {
                     bike.update(keyPath: \.status, to: status)
                     bike.update(keyPath: \.year, to: years[index])
                     bike.update(keyPath: \.manufacturerName, to: manufacturers[index])
+                    bike.update(keyPath: \.frameColorPrimary, to: colors[index])
                     print(
                         "Pre-insert bike \(bike.identifier) with \(bike.status.rawValue) / status string = \(bike.statusString)"
                     )
@@ -202,6 +204,7 @@ struct MainContentPage: View {
                     "Giant", "Specialized", "Jamis", "Giant", "Specialized", "Jamis",
                 ]
                 let years: [Int?] = [2025, 2024, 2020, 2015, 2014, nil]
+                let colors: [FrameColor] = [.bareMetal, .covered, .white, .red, .black, .yellow]
 
                 for (index, status) in BikeStatus.allCases.enumerated() {
                     let bike = output.modelInstance()
@@ -212,6 +215,7 @@ struct MainContentPage: View {
                     bike.update(keyPath: \.status, to: status)
                     bike.update(keyPath: \.year, to: years[index])
                     bike.update(keyPath: \.manufacturerName, to: manufacturers[index])
+                    bike.update(keyPath: \.frameColorPrimary, to: colors[index])
                     print(
                         "Pre-insert bike \(bike.identifier) with \(bike.status.rawValue) / status string = \(bike.statusString)"
                     )

--- a/BikeIndex/View/MainContent/MainContentPage.swift
+++ b/BikeIndex/View/MainContent/MainContentPage.swift
@@ -205,6 +205,7 @@ struct MainContentPage: View {
                 ]
                 let years: [Int?] = [2025, 2024, 2020, 2015, 2014, nil]
                 let colors: [FrameColor] = [.bareMetal, .covered, .white, .red, .black, .yellow]
+                let secondColors: [FrameColor] = [.green, .purple, .orange, .brown, .pink, .teal]
 
                 for (index, status) in BikeStatus.allCases.enumerated() {
                     let bike = output.modelInstance()
@@ -216,6 +217,7 @@ struct MainContentPage: View {
                     bike.update(keyPath: \.year, to: years[index])
                     bike.update(keyPath: \.manufacturerName, to: manufacturers[index])
                     bike.update(keyPath: \.frameColorPrimary, to: colors[index])
+                    bike.update(keyPath: \.frameColorSecondary, to: secondColors[index])
                     print(
                         "Pre-insert bike \(bike.identifier) with \(bike.status.rawValue) / status string = \(bike.statusString)"
                     )

--- a/UnitTests/Data/BikeModelTests.swift
+++ b/UnitTests/Data/BikeModelTests.swift
@@ -22,7 +22,7 @@ final class BikeModelTests: XCTestCase {
         XCTAssertEqual(bike.bikeDescription, "26 Giant Trance X  ")
         XCTAssertEqual(bike.frameModel, "Trance X")
         XCTAssertEqual(bike.typeOfCycle, .bike)
-        XCTAssertEqual(bike.frameColors, [.green, .blue])
+        XCTAssertEqual(bike.frameColors, [.green])
         XCTAssertEqual(bike.manufacturerName, "Giant")
         XCTAssertEqual(bike.serial, "GS020355")
 

--- a/UnitTests/Data/BikeRegistrationModelTests.swift
+++ b/UnitTests/Data/BikeRegistrationModelTests.swift
@@ -27,7 +27,7 @@ struct BikeRegistrationModelTests {
             ownerEmail: "")
 
         #expect(registrationModel.primary_frame_color == "green")
-        #expect(registrationModel.secondary_frame_color == "blue")
+        #expect(registrationModel.secondary_frame_color == nil)
         #expect(registrationModel.tertiary_frame_color == "stickers tape or other cover-up")
 
         #expect(registrationModel.cycle_type_name == .bike)


### PR DESCRIPTION
- Replace solid-blue monoculture placeholder background
- with column gradients based on the bike's frame colors (up to 3)
- Add hard-coded values from selections/colors API which add BikeIndex-specific frame color values to use
- The selections/colors API values are mixed with SwiftUI default semantic color values to create gradients on FrameColorBackground and Chip views (used in registration and contributor-location attribution)
- Update mocks and previews frame color values for development

### Screenshots

<img width="1512" height="933" alt="Screenshot 2026-02-08 at 13 31 27" src="https://github.com/user-attachments/assets/7a0fa296-fdeb-43e5-bc8e-e1aab9b95ed4" />
<img width="1512" height="933" alt="Screenshot 2026-02-08 at 13 32 11" src="https://github.com/user-attachments/assets/34e9fb59-7d2a-48ae-bab8-b782f6e8989e" />

