### PR TITLE
feat: Add stolen_record field to FullBikeResponse

### DIFF
--- a/BikeIndex/Model/Bike.swift
+++ b/BikeIndex/Model/Bike.swift
@@ -113,6 +113,7 @@ import SwiftData
     var frontGearTypeSlug: String?
     var rearGearTypeSlug: String?
     var additionalRegistration: String?
+    var stolenRecord: FetchedBikeStolenRecord?
     var components: [String] = []
 
     struct Constants {
@@ -168,6 +169,7 @@ import SwiftData
         frontGearTypeSlug: String? = nil,
         rearGearTypeSlug: String? = nil,
         additionalRegistration: String? = nil,
+        stolenRecord: FetchedBikeStolenRecord? = nil,
         components: [String] = []
     ) {
         self.identifier = identifier
@@ -214,6 +216,7 @@ import SwiftData
         self.frontGearTypeSlug = frontGearTypeSlug
         self.rearGearTypeSlug = rearGearTypeSlug
         self.additionalRegistration = additionalRegistration
+        self.stolenRecord = stolenRecord
         self.components = components
     }
 

--- a/BikeIndex/Model/FetchedBikeStolenRecord.swift
+++ b/BikeIndex/Model/FetchedBikeStolenRecord.swift
@@ -1,0 +1,25 @@
+//
+//  FetchedBikeStolenRecord.swift
+//  BikeIndex
+//
+//  Created by Milo Wyner on 2/13/26.
+//
+
+import CoreLocation
+
+/// Data model to represent a stolen record when fetching a bike.
+/// See https://bikeindex.org/documentation/api_v3#!/bikes/GET_version_bikes_id_format_get_0
+struct FetchedBikeStolenRecord: Codable {
+    let date_stolen: Int?
+    let location: String?
+    let latitude: CLLocationDegrees?
+    let longitude: CLLocationDegrees?
+    let theft_description: String?
+    let locking_description: String?
+    let lock_defeat_description: String?
+    let police_report_number: String?
+    let police_report_department: String?
+    let created_at: TimeInterval?
+    let create_open311: Bool?
+    let id: Int?
+}

--- a/BikeIndex/Model/FullBikeResponse.swift
+++ b/BikeIndex/Model/FullBikeResponse.swift
@@ -97,6 +97,8 @@ struct FullBikeResponse: ResponseModelInstantiable {
     let front_gear_type_slug: String?
     let rear_gear_type_slug: String?
     let additional_registration: String?
+
+    let stolen_record: FetchedBikeStolenRecord?
     let components: [String]
 
     // MARK: - ResponseModelInstantiable for BikeResponse
@@ -171,6 +173,7 @@ struct FullBikeResponse: ResponseModelInstantiable {
             frontGearTypeSlug: front_gear_type_slug,
             rearGearTypeSlug: rear_gear_type_slug,
             additionalRegistration: additional_registration,
+            stolenRecord: stolen_record,
             components: components
         )
     }

--- a/BikeIndex/Model/Registering/BikeRegistration.swift
+++ b/BikeIndex/Model/Registering/BikeRegistration.swift
@@ -53,13 +53,13 @@ struct BikeRegistration: Encodable {
 
     /// Struct type with special encoding logic
     var propulsion: Propulsion?
-    var stolen_record: StolenRecord?
+    var stolen_record: RegisterBikeStolenRecord?
     var components: [Component]?
 
     init(
         bike: Bike,
         mode: RegisterMode,
-        stolen: StolenRecord?,
+        stolen: RegisterBikeStolenRecord?,
         propulsion: Propulsion?,
         ownerEmail: String
     ) {

--- a/BikeIndex/Model/Registering/RegisterBikeStolenRecord.swift
+++ b/BikeIndex/Model/Registering/RegisterBikeStolenRecord.swift
@@ -1,5 +1,5 @@
 //
-//  StolenRecord.swift
+//  RegisterBikeStolenRecord.swift
 //  BikeIndex
 //
 //  Created by Jack on 1/13/24.
@@ -10,7 +10,7 @@ import Foundation
 /// Data model to represent a stolen bike when creating a new registration.
 /// Required fields are phone and city.
 /// See https://bikeindex.org/documentation/api_v3#!/bikes/POST_version_bikes_format_post_3
-struct StolenRecord: Encodable {
+struct RegisterBikeStolenRecord: Codable {
     var phone: String
     var city: String
     var country: Countries.ISO? = Locale.current.region?.identifier

--- a/BikeIndex/View/Registering/StolenRecordEntryView.swift
+++ b/BikeIndex/View/Registering/StolenRecordEntryView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StolenRecordEntryView: View {
-    @Binding var record: StolenRecord
+    @Binding var record: RegisterBikeStolenRecord
     @FocusState.Binding var focus: RegisterBikeView.Field?
 
     var body: some View {
@@ -83,7 +83,7 @@ struct StolenRecordEntryView: View {
 }
 
 #Preview {
-    @Previewable @State var record = StolenRecord(phone: "", city: "")
+    @Previewable @State var record = RegisterBikeStolenRecord(phone: "", city: "")
     @Previewable @FocusState var focus: RegisterBikeView.Field?
 
     Form {

--- a/BikeIndex/ViewModel/Registering/RegisterBikeViewModel.swift
+++ b/BikeIndex/ViewModel/Registering/RegisterBikeViewModel.swift
@@ -18,7 +18,7 @@ extension RegisterBikeView {
         init(
             mode: RegisterMode, bike: Bike = Bike(),
             propulsion: BikeRegistration.Propulsion = BikeRegistration.Propulsion(),
-            stolenRecord: StolenRecord = StolenRecord(phone: "", city: ""),
+            stolenRecord: RegisterBikeStolenRecord = RegisterBikeStolenRecord(phone: "", city: ""),
             output: AddBikeOutput = AddBikeOutput()
         ) {
             self.mode = mode
@@ -36,7 +36,7 @@ extension RegisterBikeView {
         /// Sub-model for electric/throttle/pedal-assist behavior. Will be combined with BikeRegistration inside ``registerBike()`` function.
         var propulsion = BikeRegistration.Propulsion()
         /// Sub-model for stolen bikes.
-        var stolenRecord = StolenRecord(phone: "", city: "")
+        var stolenRecord = RegisterBikeStolenRecord(phone: "", city: "")
         /// Track if any errors occurred when submitting this bike
         /// and report them back up to the UI
         var output = AddBikeOutput()

--- a/UnitTests/Data/FullBikeResponseTests.swift
+++ b/UnitTests/Data/FullBikeResponseTests.swift
@@ -59,6 +59,21 @@ struct FullBikeResponseTests {
         #expect(bike.frontGearTypeSlug == "MOCK_FRONT_GEAR_TYPE")
         #expect(bike.rearGearTypeSlug == "MOCK_REAR_GEAR_TYPE")
         #expect(bike.additionalRegistration == "MOCK_ADDITIONAL_REGISTRATION")
+        
+        let stolenRecord = try #require(bike.stolenRecord)
+        #expect(stolenRecord.date_stolen == 1376719200)
+        #expect(stolenRecord.location == "Portland, OR 97209, US")
+        #expect(stolenRecord.latitude == 45.53)
+        #expect(stolenRecord.longitude == -122.69)
+        #expect(stolenRecord.theft_description == "Bike rack Reward: Tbd")
+        #expect(stolenRecord.locking_description == nil)
+        #expect(stolenRecord.lock_defeat_description == nil)
+        #expect(stolenRecord.police_report_number == "1368801")
+        #expect(stolenRecord.police_report_department == "Portland")
+        #expect(stolenRecord.created_at == 1402778082)
+        #expect(stolenRecord.create_open311 == false)
+        #expect(stolenRecord.id == 16690)
+        
         #expect(bike.components == ["MOCK_COMPONENT_1", "MOCK_COMPONENT_2"])
     }
 

--- a/UnitTests/ViewModel/RegisterBikeViewModelTests.swift
+++ b/UnitTests/ViewModel/RegisterBikeViewModelTests.swift
@@ -16,7 +16,7 @@ struct RegisterBikeViewModelTests {
     @Test func test_inputs() async throws {
         let testBike = Bike()
         let testPropulsion = BikeRegistration.Propulsion()
-        let testStolenRecord = StolenRecord(phone: "", city: "")
+        let testStolenRecord = RegisterBikeStolenRecord(phone: "", city: "")
         let testOutput = AddBikeOutput()
 
         let system = ViewModel(


### PR DESCRIPTION
- Adds stolen_record field of type FetchedBikeStolenRecord.
- Renames existing StolenRecord model to RegisterBikeStolenRecord.
- Adds expectations for bike.stolenRecord's properties to parsingModel test in FullBikeResponseTests.