### PR TITLE
Update to Xcode 26.4, update packages

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -18,7 +18,7 @@ jobs:
     needs: requires-integration-tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
       - name: Set Xcode 26.4

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -21,8 +21,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-      - name: Set Xcode 26.2
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+      - name: Set Xcode 26.4
+        run: sudo xcode-select -s /Applications/Xcode_26.4.app
       - name: Strip SnapshotPreviews package
         run: |
           brew install swift-sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,7 +37,7 @@ jobs:
         run: fastlane scan --build_for_testing=true
       - name: Save build products directory
         id: cache-build-save
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: build
           key: cache-build-${{ github.sha }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         device: ["iPhone 17"] # "iPhone 17 Pro", "iPad (A16)"
-        deployment_target_version: ["26.4"]
+        deployment_target_version: ["26.4.1"]
         only-testing: ["UnitTests", "UITests"]
     steps:
       - name: Checkout

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         device: ["iPhone 17"] # "iPhone 17 Pro", "iPad (A16)"
-        deployment_target_version: ["26.4.1"]
+        deployment_target_version: ["26.4"]
         only-testing: ["UnitTests", "UITests"]
     steps:
       - name: Checkout

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,8 +17,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-      - name: Set Xcode 26.2
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+      - name: Set Xcode 26.4
+        run: sudo xcode-select -s /Applications/Xcode_26.4.app
       - name: Install tools
         run: brew bundle install
       - name: Set up xcconfig (see README.md#quick-start)
@@ -49,15 +49,15 @@ jobs:
     strategy:
       matrix:
         device: ["iPhone 17"] # "iPhone 17 Pro", "iPad (A16)"
-        deployment_target_version: ["26.2"]
+        deployment_target_version: ["26.4"]
         only-testing: ["UnitTests", "UITests"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
-      - name: Set Xcode 26.2
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+      - name: Set Xcode 26.4
+        run: sudo xcode-select -s /Applications/Xcode_26.4.app
       - name: Restore cached build products
         id: cache-build-restore
         uses: actions/cache/restore@v4

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
       - name: Set Xcode 26.4
@@ -53,7 +53,7 @@ jobs:
         only-testing: ["UnitTests", "UITests"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
       - name: Set Xcode 26.4

--- a/BikeIndex.xcodeproj/project.pbxproj
+++ b/BikeIndex.xcodeproj/project.pbxproj
@@ -495,7 +495,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = BikeIndex/BikeIndex.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 67;
+				CURRENT_PROJECT_VERSION = 69;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "BikeIndex/Preview\\ Content/MultipleBikeResponse_mock.json BikeIndex/Preview\\ Content";
 				DEVELOPMENT_TEAM = 8ZM5ZL6ABT;
@@ -639,7 +639,7 @@
 				CODE_SIGN_ENTITLEMENTS = BikeIndex/BikeIndex.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 67;
+				CURRENT_PROJECT_VERSION = 69;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "BikeIndex/Preview\\ Content/MultipleBikeResponse_mock.json BikeIndex/Preview\\ Content";
 				DEVELOPMENT_TEAM = 8ZM5ZL6ABT;
@@ -786,7 +786,7 @@
 			repositoryURL = "https://github.com/EmergeTools/SnapshotPreviews";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.11.0;
+				minimumVersion = 0.14.0;
 			};
 		};
 		04E1343C2B4B718200CE88DD /* XCRemoteSwiftPackageReference "WebViewKit" */ = {

--- a/BikeIndex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/BikeIndex.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6316d803d2415a1444535cf267b4c225fc9e4c9bbd32d14a78627ec3087cf111",
+  "originHash" : "9259fcf422692f5f3faa294a4fcee9f5ad053185cbd9f25442d308349c207968",
   "pins" : [
     {
       "identity" : "flyingfox",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/EmergeTools/SnapshotPreviews",
       "state" : {
-        "revision" : "6dfb281493e48e7c09ae9717593ae0b8eb47b15c",
-        "version" : "0.11.0"
+        "revision" : "ee45c68cd1b7576890c4f1bc54bbee7d5fcf3fed",
+        "version" : "0.14.0"
       }
     },
     {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :ios do
     # See Scanfile for default configuration
     scan(
       devices: ["iPhone 17"],
-      deployment_target_version: "26.2"
+      deployment_target_version: "26.4.1"
     )
   end
 
@@ -32,7 +32,7 @@ platform :ios do
     # See Scanfile for default configuration
     scan(
       devices: ["iPhone 17 Pro"],
-      deployment_target_version: "26.2"
+      deployment_target_version: "26.4.1"
     )
   end
 
@@ -41,7 +41,7 @@ platform :ios do
     # See Scanfile for default configuration
     scan(
       devices: ["iPad (A16)"],
-      deployment_target_version: "26.2"
+      deployment_target_version: "26.4.1"
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :ios do
     # See Scanfile for default configuration
     scan(
       devices: ["iPhone 17"],
-      deployment_target_version: "26.4.1"
+      deployment_target_version: "26.4"
     )
   end
 
@@ -32,7 +32,7 @@ platform :ios do
     # See Scanfile for default configuration
     scan(
       devices: ["iPhone 17 Pro"],
-      deployment_target_version: "26.4.1"
+      deployment_target_version: "26.4"
     )
   end
 
@@ -41,7 +41,7 @@ platform :ios do
     # See Scanfile for default configuration
     scan(
       devices: ["iPad (A16)"],
-      deployment_target_version: "26.4.1"
+      deployment_target_version: "26.4"
     )
   end
 

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -10,7 +10,7 @@ testplan("AllTests")
 
 # Scanfile contains defaults and these can be overridden by Fastfile
 # or CLI arguments
-deployment_target_version = "26.4.1"
+deployment_target_version = "26.4"
 
 disable_concurrent_testing(true)
 result_bundle(true)

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -10,7 +10,7 @@ testplan("AllTests")
 
 # Scanfile contains defaults and these can be overridden by Fastfile
 # or CLI arguments
-deployment_target_version = "26.2"
+deployment_target_version = "26.4.1"
 
 disable_concurrent_testing(true)
 result_bundle(true)


### PR DESCRIPTION
# Description

- Update to Xcode 26.4 and simulators in project file, fastlane and CI/CD
- Update Swift packages (SnapshotPreviews)
- Update actions/checkout and actions/cache for node compatibility
