### PR TITLE
CI/CD: Add TestFlight release notes from commit log

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -49,7 +49,7 @@ jobs:
         run: fastlane CD_build_release_archive
       - name: Calculate delivery changes
         run: git diff > delivery-changes.patch
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: success()
         with:
           name: ${{ github.sha }}-artifact

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,7 +60,7 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_26.4.app
       - name: Restore cached build products
         id: cache-build-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: build
           key: cache-build-${{ github.sha }}
@@ -76,7 +76,7 @@ jobs:
           echo "$BIKE_INDEX_TEST_CREDENTIALS" >> Test-credentials.xcconfig
       - name: ${{ matrix.only-testing}} on ${{ matrix.device }} ${{ matrix.deployment_target_version }}
         run: fastlane scan --only-testing="${{ matrix.only-testing }}" --device="${{ matrix.device }}" --deployment-target-version="${{ matrix.deployment_target_version }}" --test_without_building=true
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: always()
         with:
           name: test_output_${{ matrix.device }}_${{ matrix.only-testing }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -97,6 +97,9 @@ platform :ios do
       api_key_path: "./fastlane/api-key.json",
       skip_screenshots: true,
       skip_metadata: true,
+      release_notes: {
+        default: changelog_from_git_commits()
+      },
       precheck_include_in_app_purchases: false,
       copyright: "2025 © Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194"
     )


### PR DESCRIPTION
- **CICD: Add changelog deliver step**
- **CICD: Fix more GHA node runtime warnings**

Documentation
1. fastlane > Deliver > parameters > release_notes https://docs.fastlane.tools/actions/deliver/#parameters
2. fastlane > changelog_from_git_commits https://docs.fastlane.tools/actions/changelog_from_git_commits/