### PR TITLE
fix: Split FetchedBikeStolenRecord into DTO and @Model

### DIFF
--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -69,6 +69,7 @@ struct BikeIndexApp: App {
             AutocompleteManufacturer.self,
             ScannedBike.self,  // QR sticker history
             FullPublicImage.self,
+            StolenBikeRecord.self,
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 

--- a/BikeIndex/Model/Bike.swift
+++ b/BikeIndex/Model/Bike.swift
@@ -113,7 +113,7 @@ import SwiftData
     var frontGearTypeSlug: String?
     var rearGearTypeSlug: String?
     var additionalRegistration: String?
-    var stolenRecord: FetchedBikeStolenRecord?
+    var stolenRecord: StolenBikeRecord?
     var components: [Component]
 
     struct Constants {
@@ -169,7 +169,7 @@ import SwiftData
         frontGearTypeSlug: String? = nil,
         rearGearTypeSlug: String? = nil,
         additionalRegistration: String? = nil,
-        stolenRecord: FetchedBikeStolenRecord? = nil,
+        stolenRecord: StolenBikeRecord? = nil,
         components: [Component] = []
     ) {
         self.identifier = identifier

--- a/BikeIndex/Model/DTO/FullBikeResponse.swift
+++ b/BikeIndex/Model/DTO/FullBikeResponse.swift
@@ -173,7 +173,7 @@ struct FullBikeResponse: ResponseModelInstantiable {
             frontGearTypeSlug: front_gear_type_slug,
             rearGearTypeSlug: rear_gear_type_slug,
             additionalRegistration: additional_registration,
-            stolenRecord: stolen_record,
+            stolenRecord: stolen_record?.modelInstance(),
             components: components.modelInstances()
         )
     }

--- a/BikeIndex/Model/FetchedBikeStolenRecord.swift
+++ b/BikeIndex/Model/FetchedBikeStolenRecord.swift
@@ -9,8 +9,10 @@ import CoreLocation
 
 /// Data model to represent a stolen record when fetching a bike.
 /// See https://bikeindex.org/documentation/api_v3#!/bikes/GET_version_bikes_id_format_get_0
-struct FetchedBikeStolenRecord: Codable {
-    let date_stolen: Int?
+struct FetchedBikeStolenRecord: Codable, ResponseModelInstantiable {
+    typealias ModelInstance = StolenBikeRecord
+
+    let date_stolen: TimeInterval?
     let location: String?
     let latitude: CLLocationDegrees?
     let longitude: CLLocationDegrees?
@@ -22,4 +24,21 @@ struct FetchedBikeStolenRecord: Codable {
     let created_at: TimeInterval?
     let create_open311: Bool?
     let id: Int?
+
+    func modelInstance() -> StolenBikeRecord {
+        StolenBikeRecord(
+            dateStolen: date_stolen.map { Date(timeIntervalSince1970: $0) },
+            location: location,
+            latitude: latitude,
+            longitude: longitude,
+            theftDescription: theft_description,
+            lockingDescription: locking_description,
+            lockDefeatDescription: lock_defeat_description,
+            policeReportNumber: police_report_number,
+            policeReportDepartment: police_report_department,
+            createdAt: created_at.map { Date(timeIntervalSince1970: $0) },
+            createOpen311: create_open311,
+            id: id
+        )
+    }
 }

--- a/BikeIndex/Model/StolenBikeRecord.swift
+++ b/BikeIndex/Model/StolenBikeRecord.swift
@@ -1,0 +1,71 @@
+//
+//  StolenBikeRecord.swift
+//  BikeIndex
+//
+//  Created by Jack on 5/6/26.
+//
+
+import CoreLocation
+import Foundation
+import SwiftData
+
+@Model final class StolenBikeRecord {
+    @Relationship(inverse: \Bike.stolenRecord)
+    var bike: Bike?
+
+    var dateStolen: Date?
+    var location: String?
+    var latitude: CLLocationDegrees?
+    var longitude: CLLocationDegrees?
+    var theftDescription: String?
+    var lockingDescription: String?
+    var lockDefeatDescription: String?
+    var policeReportNumber: String?
+    var policeReportDepartment: String?
+    var createdAt: Date?
+    var createOpen311: Bool?
+    var id: Int?
+
+    init(
+        dateStolen: Date?,
+        location: String?,
+        latitude: CLLocationDegrees?,
+        longitude: CLLocationDegrees?,
+        theftDescription: String?,
+        lockingDescription: String?,
+        lockDefeatDescription: String?,
+        policeReportNumber: String?,
+        policeReportDepartment: String?,
+        createdAt: Date?,
+        createOpen311: Bool?,
+        id: Int?
+    ) {
+        self.dateStolen = dateStolen
+        self.location = location
+        self.latitude = latitude
+        self.longitude = longitude
+        self.theftDescription = theftDescription
+        self.lockingDescription = lockingDescription
+        self.lockDefeatDescription = lockDefeatDescription
+        self.policeReportNumber = policeReportNumber
+        self.policeReportDepartment = policeReportDepartment
+        self.createdAt = createdAt
+        self.createOpen311 = createOpen311
+        self.id = id
+    }
+
+    init() {
+        dateStolen = nil
+        location = ""
+        latitude = 0
+        longitude = 0
+        theftDescription = ""
+        lockingDescription = ""
+        lockDefeatDescription = ""
+        policeReportNumber = ""
+        policeReportDepartment = ""
+        createdAt = nil
+        createOpen311 = false
+        id = nil
+    }
+}

--- a/UnitTests/Data/FullBikeResponseTests.swift
+++ b/UnitTests/Data/FullBikeResponseTests.swift
@@ -60,18 +60,33 @@ struct FullBikeResponseTests {
         #expect(bike.rearGearTypeSlug == "MOCK_REAR_GEAR_TYPE")
         #expect(bike.additionalRegistration == "MOCK_ADDITIONAL_REGISTRATION")
 
+        // Interlude: check DTO too
+        let dtoStolenRecord = try #require(output.stolen_record)
+        #expect(dtoStolenRecord.date_stolen == 1_376_719_200)
+        #expect(dtoStolenRecord.location == "Portland, OR 97209, US")
+        #expect(dtoStolenRecord.latitude == 45.53)
+        #expect(dtoStolenRecord.longitude == -122.69)
+        #expect(dtoStolenRecord.theft_description == "Bike rack Reward: Tbd")
+        #expect(dtoStolenRecord.locking_description == nil)
+        #expect(dtoStolenRecord.lock_defeat_description == nil)
+        #expect(dtoStolenRecord.police_report_number == "1368801")
+        #expect(dtoStolenRecord.police_report_department == "Portland")
+        #expect(dtoStolenRecord.created_at == 1_402_778_082)
+        #expect(dtoStolenRecord.create_open311 == false)
+        #expect(dtoStolenRecord.id == 16690)
+
         let stolenRecord = try #require(bike.stolenRecord)
-        #expect(stolenRecord.date_stolen == 1_376_719_200)
+        #expect(stolenRecord.dateStolen == Date(timeIntervalSince1970: 1_376_719_200))
         #expect(stolenRecord.location == "Portland, OR 97209, US")
         #expect(stolenRecord.latitude == 45.53)
         #expect(stolenRecord.longitude == -122.69)
-        #expect(stolenRecord.theft_description == "Bike rack Reward: Tbd")
-        #expect(stolenRecord.locking_description == nil)
-        #expect(stolenRecord.lock_defeat_description == nil)
-        #expect(stolenRecord.police_report_number == "1368801")
-        #expect(stolenRecord.police_report_department == "Portland")
-        #expect(stolenRecord.created_at == 1_402_778_082)
-        #expect(stolenRecord.create_open311 == false)
+        #expect(stolenRecord.theftDescription == "Bike rack Reward: Tbd")
+        #expect(stolenRecord.lockingDescription == nil)
+        #expect(stolenRecord.lockDefeatDescription == nil)
+        #expect(stolenRecord.policeReportNumber == "1368801")
+        #expect(stolenRecord.policeReportDepartment == "Portland")
+        #expect(stolenRecord.createdAt == Date(timeIntervalSince1970: 1_402_778_082))
+        #expect(stolenRecord.createOpen311 == false)
         #expect(stolenRecord.id == 16690)
 
         #expect(bike.components.count == 2)
@@ -100,5 +115,4 @@ struct FullBikeResponseTests {
         #expect(frontBrakeComponent.modelName == "")
         #expect(frontBrakeComponent.year == nil)
     }
-
 }


### PR DESCRIPTION
- Missed distinction in last big addition
- Docs: https://bikeindex.org/documentation/api_v3#!/bikes/GET_version_bikes_id_format_get_0
- FetchedBikeStolenRecord was being used both as a DTO in FullBikeResponse and stored directly on the Bike @Model. Create a new StolenBikeRecord @Model class and have FetchedBikeStolenRecord conform to ResponseModelInstantiable with modelInstance() -> StolenBikeRecord, matching the existing pattern for ComponentsResponse/Component and PublicImageResponse/FullPublicImage.