### PR TITLE
Fix: extra registration number - ignore Int? / add String?

### DIFF
--- a/BikeIndex/BikeIndexApp.swift
+++ b/BikeIndex/BikeIndexApp.swift
@@ -73,9 +73,14 @@ struct BikeIndexApp: App {
         ])
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
 
-        let sharedModelContainer = try! ModelContainer(
-            for: schema, configurations: [modelConfiguration])
-        self.sharedModelContainer = sharedModelContainer
+        do {
+            let sharedModelContainer = try ModelContainer(
+                for: schema, configurations: [modelConfiguration])
+            self.sharedModelContainer = sharedModelContainer
+        } catch {
+            print(error)
+            fatalError(error.localizedDescription)
+        }
 
         // Give AppDelegate access to client's background session delegate
         appDelegate.backgroundSessionDelegate = client.backgroundSessionDelegate

--- a/BikeIndex/Model/Bike.swift
+++ b/BikeIndex/Model/Bike.swift
@@ -103,7 +103,10 @@ import SwiftData
     /// Date the bike was most-recently updated. Note that this is read-only from the API.
     var updatedAt: Date?
 
-    var extraRegistrationNumber: String?
+    @Attribute(originalName: "extraRegistrationNumber")
+    var ignore_extraRegistrationNumber: Int? = nil
+    /// API name: "extraRegistrationNumber".
+    var extraRegistration: String?
     var rearTireNarrow: Bool?
     var testBike: Bool?
     var rearWheelSizeISOBSD: Int?
@@ -206,7 +209,7 @@ import SwiftData
         self.isStockImage = isStockImage
         self.createdAt = createdAt
         self.updatedAt = updatedAt
-        self.extraRegistrationNumber = extraRegistrationNumber
+        self.extraRegistration = extraRegistrationNumber
         self.rearTireNarrow = rearTireNarrow
         self.testBike = testBike
         self.rearWheelSizeISOBSD = rearWheelSizeISOBSD

--- a/BikeIndex/View/Debug/DatabaseGalleryView.swift
+++ b/BikeIndex/View/Debug/DatabaseGalleryView.swift
@@ -101,6 +101,32 @@ struct DatabaseGalleryView: View {
                 Text(
                     "Full Public Images: \(bike.fullPublicImages.compactMap { $0.full?.absoluteString }.joined())"
                 )
+                Divider()
+                Text("Ignore Extra Registration Number: \(String(describing: bike.ignore_extraRegistrationNumber))")
+                if let extraRegistration = bike.extraRegistration {
+                    Text("Extra Registration: \(extraRegistration)")
+                }
+                if let rearTireNarrow = bike.rearTireNarrow {
+                    Text("Rear Tire Narrow: \(rearTireNarrow)")
+                }
+                if let testBike = bike.testBike {
+                    Text("Test Bike: \(testBike)")
+                }
+                if let rearWheelSizeISOBSD = bike.rearWheelSizeISOBSD {
+                    Text("Rear Wheel Size ISO/BSD: \(rearWheelSizeISOBSD)")
+                }
+                if let frontWheelSizeISOBSD = bike.frontWheelSizeISOBSD {
+                    Text("Front Wheel Size ISO/BSD: \(frontWheelSizeISOBSD)")
+                }
+                Text("Handlebar Type Slug: \(bike.handlebarTypeSlug ?? "")")
+                Text("Frame Material Slug: \(bike.frameMaterialSlug ?? "")")
+                Text("Front Gear Type Slug: \(bike.frontGearTypeSlug ?? "")")
+                Text("Rear Gear Type Slug: \(bike.rearGearTypeSlug ?? "")")
+                Text("Additional Registration: \(bike.additionalRegistration ?? "")")
+                if let stolenRecord = bike.stolenRecord {
+                    Text("Stolen Record: \(String(describing: stolenRecord))")
+                }
+                Text("Components: \(bike.components.map { String(describing: $0) }.joined(separator: ", "))")
             }
 
             // MARK: - AutocompleteManufacturers

--- a/BikeIndex/View/Debug/DatabaseGalleryView.swift
+++ b/BikeIndex/View/Debug/DatabaseGalleryView.swift
@@ -120,11 +120,21 @@ struct DatabaseGalleryView: View {
                 if let frontWheelSizeISOBSD = bike.frontWheelSizeISOBSD {
                     Text("Front Wheel Size ISO/BSD: \(frontWheelSizeISOBSD)")
                 }
-                Text("Handlebar Type Slug: \(bike.handlebarTypeSlug ?? "")")
-                Text("Frame Material Slug: \(bike.frameMaterialSlug ?? "")")
-                Text("Front Gear Type Slug: \(bike.frontGearTypeSlug ?? "")")
-                Text("Rear Gear Type Slug: \(bike.rearGearTypeSlug ?? "")")
-                Text("Additional Registration: \(bike.additionalRegistration ?? "")")
+                if let handlebarTypeSlug = bike.handlebarTypeSlug {
+                    Text("Handlebar Type Slug: \(handlebarTypeSlug)")
+                }
+                if let frameMaterialSlug = bike.frameMaterialSlug {
+                    Text("Frame Material Slug: \(frameMaterialSlug)")
+                }
+                if let frontGearTypeSlug = bike.frontGearTypeSlug {
+                    Text("Front Gear Type Slug: \(frontGearTypeSlug)")
+                }
+                if let rearGearTypeSlug = bike.rearGearTypeSlug {
+                    Text("Rear Gear Type Slug: \(rearGearTypeSlug)")
+                }
+                if let additionalRegistration = bike.additionalRegistration {
+                    Text("Additional Registration: \(additionalRegistration)")
+                }
                 if let stolenRecord = bike.stolenRecord {
                     Text("Stolen Record: \(String(describing: stolenRecord))")
                 }

--- a/BikeIndex/View/Debug/DatabaseGalleryView.swift
+++ b/BikeIndex/View/Debug/DatabaseGalleryView.swift
@@ -102,7 +102,9 @@ struct DatabaseGalleryView: View {
                     "Full Public Images: \(bike.fullPublicImages.compactMap { $0.full?.absoluteString }.joined())"
                 )
                 Divider()
-                Text("Ignore Extra Registration Number: \(String(describing: bike.ignore_extraRegistrationNumber))")
+                Text(
+                    "Ignore Extra Registration Number: \(String(describing: bike.ignore_extraRegistrationNumber))"
+                )
                 if let extraRegistration = bike.extraRegistration {
                     Text("Extra Registration: \(extraRegistration)")
                 }
@@ -126,7 +128,9 @@ struct DatabaseGalleryView: View {
                 if let stolenRecord = bike.stolenRecord {
                     Text("Stolen Record: \(String(describing: stolenRecord))")
                 }
-                Text("Components: \(bike.components.map { String(describing: $0) }.joined(separator: ", "))")
+                Text(
+                    "Components: \(bike.components.map { String(describing: $0) }.joined(separator: ", "))"
+                )
             }
 
             // MARK: - AutocompleteManufacturers

--- a/BikeIndex/View/Debug/DatabaseGalleryView.swift
+++ b/BikeIndex/View/Debug/DatabaseGalleryView.swift
@@ -73,7 +73,7 @@ struct DatabaseGalleryView: View {
                 if let stolenCoordinates = bike.stolenCoordinates {
                     Text("Stolen Coordinates: \(stolenCoordinates))")
                 }
-                Text("Stolen: \(bike.stolen)")
+                Text("Stolen: \(String(bike.stolen))")
                 if let stolenLocation = bike.stolenLocation {
                     Text("Stolen Location: \(stolenLocation))")
                 }
@@ -81,7 +81,7 @@ struct DatabaseGalleryView: View {
                     Text("Date Stolen: \(dateStolen))")
                 }
                 if let locationFound = bike.locationFound {
-                    Text("Location Found: \(locationFound)")
+                    Text("Location Found: \(String(locationFound))")
                 }
                 if let largeImage = bike.largeImage {
                     Text("Large Image: \(largeImage))")
@@ -89,7 +89,7 @@ struct DatabaseGalleryView: View {
                 if let thumb = bike.thumb {
                     Text("Thumb: \(thumb))")
                 }
-                Text("Is Stock Image: \(bike.isStockImage)")
+                Text("Is Stock Image: \(String(bike.isStockImage))")
                 Text("Url: \(bike.url)")
                 if let apiUrl = bike.apiUrl {
                     Text("Api Url: \(apiUrl))")
@@ -107,10 +107,10 @@ struct DatabaseGalleryView: View {
                     Text("Extra Registration: \(extraRegistration)")
                 }
                 if let rearTireNarrow = bike.rearTireNarrow {
-                    Text("Rear Tire Narrow: \(rearTireNarrow)")
+                    Text("Rear Tire Narrow: \(String(rearTireNarrow))")
                 }
                 if let testBike = bike.testBike {
-                    Text("Test Bike: \(testBike)")
+                    Text("Test Bike: \(String(testBike))")
                 }
                 if let rearWheelSizeISOBSD = bike.rearWheelSizeISOBSD {
                     Text("Rear Wheel Size ISO/BSD: \(rearWheelSizeISOBSD)")

--- a/BikeIndex/View/Debug/DatabaseGalleryView.swift
+++ b/BikeIndex/View/Debug/DatabaseGalleryView.swift
@@ -38,9 +38,14 @@ struct DatabaseGalleryView: View {
             // MARK: - Bikes
             DataModelDebugView(models: bikes) { bike in
                 Text("ID: \(bike.identifier, format: .number.grouping(.never))")
+                Text("Registry Name: \(bike.registryName ?? "")")
+                if let registryURL = bike.registryURL {
+                    Text("Registry URL: \(registryURL)")
+                }
                 Text("Owner [UUID]: \(bike.owner?.persistentModelID.storeIdentifier ?? "Empty")")
                 Text("Auth Owner [ID]: \(bike.authenticatedOwner?.identifier ?? "Empty")")
                 Text("Description: \(bike.bikeDescription ?? "")")
+                Text("Paint Description: \(bike.paintDescription ?? "")")
                 Text("Frame Model: \(String(describing: bike.frameModel))")
                 Text("Color Primary: \(bike.frameColorPrimary.displayValue)")
                 if let frameColorSecondary = bike.frameColorSecondary {
@@ -51,23 +56,32 @@ struct DatabaseGalleryView: View {
                 }
                 Text("Frame Colors: \(bike.frameColors.map { $0.displayValue }.joined())")
                 Text("Manufacturer Name: \(bike.manufacturerName)")
-                if let year = bike.year {
-                    Text("Year: \(year))")
+                if let manufacturerID = bike.manufacturerID {
+                    Text("Manufacturer ID: \(manufacturerID)")
                 }
+                if let year = bike.year {
+                    Text(verbatim: "Year: \(year)")
+                }
+                Text("Year String: \(bike.yearString)")
                 Text("Type Of Cycle: \(bike.typeOfCycle.name)")
                 Text("Type Of Propulsion: \(bike.typeOfPropulsion.name)")
                 if let serial = bike.serial {
                     Text("Serial: \(serial))")
                 }
                 Text("Status: \(bike.status.displayName)")
+                Text("Status String: \(bike.statusString)")
                 if let stolenCoordinates = bike.stolenCoordinates {
                     Text("Stolen Coordinates: \(stolenCoordinates))")
                 }
+                Text("Stolen: \(bike.stolen)")
                 if let stolenLocation = bike.stolenLocation {
                     Text("Stolen Location: \(stolenLocation))")
                 }
                 if let dateStolen = bike.dateStolen {
                     Text("Date Stolen: \(dateStolen))")
+                }
+                if let locationFound = bike.locationFound {
+                    Text("Location Found: \(locationFound)")
                 }
                 if let largeImage = bike.largeImage {
                     Text("Large Image: \(largeImage))")
@@ -75,6 +89,7 @@ struct DatabaseGalleryView: View {
                 if let thumb = bike.thumb {
                     Text("Thumb: \(thumb))")
                 }
+                Text("Is Stock Image: \(bike.isStockImage)")
                 Text("Url: \(bike.url)")
                 if let apiUrl = bike.apiUrl {
                     Text("Api Url: \(apiUrl))")

--- a/UnitTests/Data/FullBikeResponseTests.swift
+++ b/UnitTests/Data/FullBikeResponseTests.swift
@@ -49,7 +49,7 @@ struct FullBikeResponseTests {
         #expect(bike.createdAt == Date(timeIntervalSince1970: 1_377_151_200))
         #expect(bike.updatedAt == Date(timeIntervalSince1970: 1_585_269_739))
 
-        #expect(bike.extraRegistrationNumber == "1234")
+        #expect(bike.extraRegistration == "1234")
         #expect(bike.rearTireNarrow == true)
         #expect(bike.testBike == false)
         #expect(bike.rearWheelSizeISOBSD == nil)


### PR DESCRIPTION
# Description

- Fix offline Full Bike fetching by setting aside `Bike.extraRegistrationNumber: Int?` with an 'ignore_' prefix
- Add `Bike.extraRegistration: String?`
- Add more Full Bike fields to debug database gallery view
- 