### PR TITLE
Fix: sign-in - Guard against duplicate web view navigations

### DIFF
--- a/BikeIndex/View/Onboarding/AuthSignInView.swift
+++ b/BikeIndex/View/Onboarding/AuthSignInView.swift
@@ -13,7 +13,17 @@ struct AuthSignInView: View {
     @State var baseUrl: URL
     var navigator: HistoryNavigator
     @Binding var display: Bool
-    @State private var title: String = "Sign in"
+    @State private var title: String
+
+    init(
+        baseUrl: URL, navigator: HistoryNavigator, display: Binding<Bool>, title: String = "Sign in"
+    ) {
+        self.baseUrl = baseUrl
+        self.navigator = navigator
+        self._display = display
+        self.title = title
+        assert(self.navigator.child is AuthenticationNavigator)
+    }
 
     var body: some View {
         @Bindable var stickerRouter = stickerRouter

--- a/BikeIndex/View/Onboarding/AuthView.swift
+++ b/BikeIndex/View/Onboarding/AuthView.swift
@@ -64,18 +64,13 @@ struct AuthView: View {
                 // Also supports QR-code bike display in a web view.
                 AuthSignInView(
                     baseUrl: viewModel.signInPageRequest.url!,
+                    // pre-condition: historyNavigator.child is assigned to viewModel.authNavigator
                     navigator: viewModel.historyNavigator,
                     display: $viewModel.displaySignIn
                 )
                 .environment(client)
                 .environment(stickerRouter)
                 .interactiveDismissDisabled()
-                .onAppear {
-                    viewModel.authNavigator.routeToAuthenticationPage = {
-                        let webView = viewModel.historyNavigator.wkWebView
-                        webView?.load(viewModel.signInPageRequest)
-                    }
-                }
             }
         )
         .fullScreenCover(isPresented: $stickerRouter.displayStickerCenter) {
@@ -86,7 +81,7 @@ struct AuthView: View {
         .onAppear {
             /// Connect AuthView.viewModel.authenticationNavigator.client at runtime
             /// so that AuthenticationNavigator can respond to sign-in and complete the flow.
-            viewModel.authNavigator.client = client
+            viewModel.assign(client: client)
         }
     }
 }

--- a/BikeIndex/View/Web/AuthenticationNavigator.swift
+++ b/BikeIndex/View/Web/AuthenticationNavigator.swift
@@ -10,43 +10,50 @@ import WebKit
 
 @Observable
 /// Delegate to intercept completed OAuth callback URLs, forward them to Client, and complete authentication.
+/// Must be annotated Observable for parent class conformance.
 final class AuthenticationNavigator: NavigationResponder {
-    @ObservationIgnored
-    /// Allow composition for ``AuthView/ViewModel`` to connect this client.
+    /// Allow ``AuthView/ViewModel`` to connect this client at runtime.
     /// Authentication cannot proceed until this value is assigned.
-    var client: Client?
-
+    @ObservationIgnored var client: Client?
     @ObservationIgnored
-    var routeToAuthenticationPage: () -> Void
-
+    let signInPageRequest: URLRequest
+    @ObservationIgnored
     private(set) var interceptor: Interceptor
 
     init(
-        client: Client? = nil, routeToAuthenticationPage: @escaping () -> Void = {},
-        interceptor: Interceptor
+        clientConfiguration: ClientConfiguration
     ) {
-        self.client = client
-        self.routeToAuthenticationPage = routeToAuthenticationPage
-        self.interceptor = interceptor
+        self.signInPageRequest = clientConfiguration.signInPageRequest
+        self.interceptor = Interceptor(hostProvider: clientConfiguration.hostProvider)
+    }
+
+    private func routeToAuthenticationPage() {
+        assert(self.wkWebView != nil)
+        self.wkWebView?.load(signInPageRequest)
     }
 
     // MARK: - Decide Policy
 
+    /// Pre-condition: self.client is not nil
     override func webView(
         _ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
         preferences: WKWebpagePreferences
     ) async -> (WKNavigationActionPolicy, WKWebpagePreferences) {
+        Logger.auth.debug("\(#file).\(#function) enter")
+        assert(client != nil)
+
         /// Flow: Guest > Sticker > Please Sign In
         /// Re-route the AuthSignInView experience away from /session/new.
         /// - /session/new is only for browser sessions.
         /// - APp sessions must use the ``AuthView/ViewModel/signInPageRequest`` page (or sign-in will fail!)
-        /// How does the user get to /session/new? A) if they navigate around the sign-in page
-        /// B) if they scan a QR code Bike Sticker
+        /// How does the user get to /session/new?
+        /// A) if they navigate around the sign-in page (ex: help -> sign in)
+        /// B) if they scan a QR code Bike Sticker (universal link)
         if let signInAction = interceptor.filterSignInRedirect(navigationAction.request.url) {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
-                self?.routeToAuthenticationPage()
-            }
+            routeToAuthenticationPage()
 
+            Logger.auth.debug(
+                "\(#file).\(#function) found a sign-in redirect, routing to authentication page")
             return (signInAction, preferences)
         }
 
@@ -57,13 +64,20 @@ final class AuthenticationNavigator: NavigationResponder {
             navigationAction.request.url,
             client: client)
         {
+            Logger.auth.debug(
+                "\(#file).\(#function) interceptor successfully completed authentication")
             return (action, preferences)
         }
 
         if let child {
-            return await child.webView(
+            let result = await child.webView(
                 webView, decidePolicyFor: navigationAction, preferences: preferences)
+            Logger.auth.debug("\(#file).\(#function) deferring decision via child navigator")
+            return result
         } else {
+            Logger.auth.debug(
+                "\(#file).\(#function) fallback: returning allow for \(String(describing: navigationAction.request.url))"
+            )
             return (.allow, preferences)
         }
     }
@@ -72,30 +86,45 @@ final class AuthenticationNavigator: NavigationResponder {
     struct Interceptor {
         var hostProvider: HostProvider
 
-        var routeToAuthentication: () -> Void = {}
-
         /// Guest > Scan Sticker QR Code > Please Sign In
         func filterSignInRedirect(_ url: URL?) -> WKNavigationActionPolicy? {
+            Logger.auth.debug(
+                "\(#file).\(#function) Enter, checking \(String(describing: url)) against session/new"
+            )
+
             guard let url,
                 let prefixTrimmed = Optional(url.absoluteString.trimmingPrefix("bikeindex://")),
                 let components = URLComponents(string: String(prefixTrimmed))
-            else { return nil }
+            else {
+                Logger.auth.debug(
+                    "\(#file).\(#function) returning nil - invalid url or components of \(String(describing: url), privacy: .auto)"
+                )
+                return nil
+            }
 
             if let baseHost = hostProvider.host.host(),
                 components.host != baseHost
             {
                 /// E.g. bikeindex.org in the input URL must match bikeindex.org
+                Logger.auth.debug(
+                    "\(#file).\(#function) exiting, host mismatch, \(baseHost) vs. \(String(describing: components.host))"
+                )
                 return nil
             }
 
+            /// Ex: `session/new?return_to=SAM000000`
             if components.path == "/session/new",
                 let returnTo = components.queryItems?.first(where: { $0.name == "return_to" }),
                 let decoded = returnTo.value?.removingPercentEncoding,
                 decoded.contains("scanned")
             {
+                Logger.auth.debug(
+                    "\(#file).\(#function) returning cancel for session/new with scanned return_to")
                 return .cancel
             }
 
+            Logger.auth.debug(
+                "\(#file).\(#function) returning nil - no matching condition against \(url)")
             return nil
         }
 
@@ -104,14 +133,21 @@ final class AuthenticationNavigator: NavigationResponder {
         func filterCompletedAuthentication(_ url: URL?, client: Client?) async
             -> WKNavigationActionPolicy?
         {
+            Logger.auth.debug("\(#file).\(#function) enter")
+
             if let url,
                 let scheme = url.scheme,
                 scheme + "://" == client?.configuration.redirectUri,
                 let result = await client?.accept(authCallback: url),
                 result == true
             {
+                Logger.auth.debug(
+                    "\(#file) \(#function) returning cancel - authentication completed")
                 return WKNavigationActionPolicy.cancel
             } else {
+                Logger.auth.debug(
+                    "\(#file).\(#function) returning nil - authentication not completed against \(String(describing: url))"
+                )
                 return nil
             }
         }

--- a/BikeIndex/View/Web/NavigableWebView.swift
+++ b/BikeIndex/View/Web/NavigableWebView.swift
@@ -5,6 +5,7 @@
 //  Created by Jack on 1/14/24.
 //
 
+import OSLog
 import SwiftUI
 import WebKit
 import WebViewKit
@@ -44,6 +45,14 @@ struct NavigableWebView: View {
         .onChange(
             of: url,
             { _, newValue in
+                if let currentURL = navigator.wkWebView?.url, currentURL == newValue {
+                    // WKWebView is already navigating to this URL. Our onChange(of: wkWebView?.url) callback triggered a binding update, which triggered this onChange(of: url). Don't load again.
+                    Logger.webNavigation.debug(
+                        "NavigableWebView onChange skip - WKWebView already at \(newValue)"
+                    )
+                    return
+                }
+
                 // Accept updates from the owning State/Binding, navigate to the new page.
                 navigator.wkWebView?.load(URLRequest(url: newValue))
             }
@@ -54,6 +63,9 @@ struct NavigableWebView: View {
                 // Accept updates from the webView (such as clicking links).
                 // After a user action causes a change, update the binding.
                 // This allows assigning new values to the binding to navigate to.
+                Logger.webNavigation.debug(
+                    "NavigableWebView onChange(of: wkWebView?.url) oldValue=\(oldValue ?? URL(stringLiteral: "nil")), newValue=\(String(describing: newValue)), currentBindingUrl=\(self.url), skippingLoad=\(newValue != url)"
+                )
                 if let newValue, newValue != url {
                     url = newValue
                 }

--- a/BikeIndex/View/Web/NavigationResponder.swift
+++ b/BikeIndex/View/Web/NavigationResponder.swift
@@ -25,6 +25,7 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
     /// Required to use NavigationResponder.
     /// - Parameter wkWebView: The web view provided by `WebViewKit.WebView.init(…, viewConfig: (WKWebView) -> Void)`
     func assign(wkWebView: WKWebView?) {
+        Logger.webNavigation.debug("\(#file).\(type(of: self)).\(#function) enter")
         self.wkWebView = wkWebView
         child?.assign(wkWebView: wkWebView)
     }
@@ -34,9 +35,16 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction)
         async -> WKNavigationActionPolicy
     {
+        Logger.webNavigation.debug("\(#file).\(type(of: self)).\(#function)-\(#line) enter")
+
         if let child {
+            Logger.webNavigation.debug(
+                "\(#file).\(type(of: self)).\(#function)-\(#line) deferring to child navigator"
+            )
             return await child.webView(webView, decidePolicyFor: navigationAction)
         } else {
+            Logger.webNavigation.debug(
+                "\(#file).\(type(of: self)).\(#function)-\(#line) returning allow - no child")
             return .allow
         }
     }
@@ -45,7 +53,12 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
         _ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
         preferences: WKWebpagePreferences
     ) async -> (WKNavigationActionPolicy, WKWebpagePreferences) {
+        Logger.webNavigation.debug("\(#file).\(type(of: self)).\(#function)-\(#line) enter")
+
         if let child {
+            Logger.webNavigation.debug(
+                "\(#file).\(type(of: self)).\(#function)-\(#line) deferring to child navigator"
+            )
             return await child.webView(
                 webView, decidePolicyFor: navigationAction, preferences: preferences)
         } else {
@@ -59,9 +72,14 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
                     string: "https://bikeindex.org/donate?referral_source=\(referralSource)")!
                 Logger.webNavigation.debug("Open donate page with referral \(donateUrl)")
                 await UIApplication.shared.open(donateUrl)
+                Logger.webNavigation.debug(
+                    "\(#file).\(type(of: self)).\(#function)-\(#line) returning cancel - donated")
                 return (WKNavigationActionPolicy.cancel, preferences)
             }
 
+            Logger.webNavigation.debug(
+                "\(#file).\(type(of: self)).\(#function)-\(#line) returning allow - no matching conditions"
+            )
             return (WKNavigationActionPolicy.allow, preferences)
         }
     }
@@ -69,9 +87,16 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
     public func webView(
         _ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse
     ) async -> WKNavigationResponsePolicy {
+        Logger.webNavigation.debug("\(#file).\(type(of: self)).\(#function)-\(#line) enter")
+
         if let child {
+            Logger.webNavigation.debug(
+                "\(#file).\(type(of: self)).\(#function)-\(#line) deferring to child navigator"
+            )
             return await child.webView(webView, decidePolicyFor: navigationResponse)
         } else {
+            Logger.webNavigation.debug(
+                "\(#file).\(type(of: self)).\(#function)-\(#line) returning allow - no child")
             return .allow
         }
     }
@@ -86,6 +111,7 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
         _ webView: WKWebView,
         didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!
     ) {
+        Logger.webNavigation.debug("\(#file).\(#function) enter")
         child?.webView(webView, didReceiveServerRedirectForProvisionalNavigation: navigation)
     }
 
@@ -93,34 +119,48 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
         _ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: Error
     ) {
+        Logger.webNavigation.debug(
+            "\(#file).\(type(of: self)).\(#function) with navigation=\(navigation), failed due to \(error)"
+        )
         child?.webView(webView, didFailProvisionalNavigation: navigation, withError: error)
     }
 
     public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        Logger.webNavigation.debug("\(#file).\(#function) enter")
         child?.webView(webView, didCommit: navigation)
     }
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        Logger.webNavigation.debug("\(#file).\(#function) enter")
         child?.webView(webView, didFinish: navigation)
     }
 
     public func webView(
         _ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error
     ) {
+        Logger.webNavigation.debug(
+            "\(#file).\(type(of: self)).\(#function) with navigation=\(navigation), failed due to \(error)"
+        )
         child?.webView(webView, didFail: navigation, withError: error)
     }
 
     public func webView(_ webView: WKWebView, respondTo challenge: URLAuthenticationChallenge) async
         -> (URLSession.AuthChallengeDisposition, URLCredential?)
     {
+        Logger.webNavigation.debug("\(#file).\(#function) enter")
+
         if let child {
             return await child.webView(webView, respondTo: challenge)
         } else {
+            Logger.webNavigation.debug(
+                "\(#file).\(#function) returning performDefaultHandling - no child"
+            )
             return (.performDefaultHandling, nil)
         }
     }
 
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        Logger.webNavigation.debug("\(#file).\(#function) enter")
         child?.webViewWebContentProcessDidTerminate(webView)
     }
 
@@ -128,18 +168,24 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
         _ webView: WKWebView, authenticationChallenge challenge: URLAuthenticationChallenge,
         shouldAllowDeprecatedTLS decisionHandler: @escaping (Bool) -> Void
     ) {
+        Logger.webNavigation.debug("\(#file).\(#function) enter")
+
         if let child {
             return child.webView(
                 webView, authenticationChallenge: challenge,
                 shouldAllowDeprecatedTLS: decisionHandler)
         } else {
             decisionHandler(false)
+            Logger.webNavigation.debug(
+                "\(#file).\(#function) returning reject - no child"
+            )
         }
     }
 
     public func webView(
         _ webView: WKWebView, navigationAction: WKNavigationAction, didBecome download: WKDownload
     ) {
+        Logger.webNavigation.debug("\(#file).\(#function) enter")
         child?.webView(webView, navigationAction: navigationAction, didBecome: download)
     }
 
@@ -147,6 +193,7 @@ open class NavigationResponder: NSObject, WKNavigationDelegate {
         _ webView: WKWebView, navigationResponse: WKNavigationResponse,
         didBecome download: WKDownload
     ) {
+        Logger.webNavigation.debug("\(#file).\(#function) enter")
         child?.webView(webView, navigationResponse: navigationResponse, didBecome: download)
     }
 }

--- a/BikeIndex/ViewModel/Onboarding/AuthViewModel.swift
+++ b/BikeIndex/ViewModel/Onboarding/AuthViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OSLog
 import SwiftUI
 
 extension ClientConfiguration {
@@ -18,6 +19,12 @@ extension ClientConfiguration {
         ].map { (item: QueryItemTuple) in
             URLQueryItem(name: item.name, value: item.value)
         }
+    }
+
+    var signInPageRequest: URLRequest {
+        OAuth.authorize(queryItems: authorizeQueryItems).request(
+            for: hostProvider
+        )
     }
 }
 
@@ -38,12 +45,11 @@ extension AuthView {
         var topLevelPath = NavigationPath()
 
         @ObservationIgnored
-        var configuration = try! ClientConfiguration.bundledConfig()
+        var configuration: ClientConfiguration
 
         init() {
             let configuration = try! ClientConfiguration.bundledConfig()
-            let authNavigator = AuthenticationNavigator(
-                interceptor: .init(hostProvider: configuration.hostProvider))
+            let authNavigator = AuthenticationNavigator(clientConfiguration: configuration)
             let historyNavigator = HistoryNavigator(child: authNavigator)
             self.authNavigator = authNavigator
             self.historyNavigator = historyNavigator
@@ -62,8 +68,13 @@ extension AuthView {
 
         /// URL helper to find the right user-facing authorization page for this app config.
         var signInPageRequest: URLRequest {
-            OAuth.authorize(queryItems: configuration.authorizeQueryItems).request(
-                for: configuration.hostProvider
+            configuration.signInPageRequest
+        }
+
+        func assign(client: Client) {
+            authNavigator.client = client
+            Logger.auth.debug(
+                "\(#file) assigned authNavigator.client to \(String(describing: client), privacy: .public)"
             )
         }
     }

--- a/UITests/Robot/Robot+Authentication.swift
+++ b/UITests/Robot/Robot+Authentication.swift
@@ -17,7 +17,7 @@ extension Robot {
 
     @discardableResult
     func signIn() throws -> Self {
-        // Step 1: Open the Sign In Page
+        // Step 1: A) Open the Sign In Page
         let signIn = app.buttons["SignIn"]
         let result = signIn.waitForExistence(timeout: 2)
 
@@ -28,10 +28,10 @@ extension Robot {
 
         signIn.tap()
 
-        // Catch any interruptions atop the OAuth authorization
+        // Step 1: B) Catch any interruptions atop the OAuth authorization
         attemptAppOAuthSecurity()
 
-        // Try to tap Authorize __if it exists__, continue if it is absent.
+        // Step 1: C) Try to tap Authorize, continue if it is absent.
         attemptOAuthAuthorize()
 
         let timeout: TimeInterval = 120
@@ -42,7 +42,7 @@ extension Robot {
         let testUsername = try XCTUnwrap(infoDictionary["TEST_USERNAME"] as? String)
         let testPassword = try XCTUnwrap(infoDictionary["TEST_PASSWORD"] as? String)
 
-        // Step 2: Fill credentials and proceed
+        // Step 2: A) Enter email
         let usernameField = app.webViews.firstMatch.textFields["Email"]
         if usernameField.waitForExistence(timeout: timeout) {
             usernameField.tap()
@@ -50,6 +50,19 @@ extension Robot {
         } else {
             XCTFail("Couldn't find email field")
         }
+
+        // Step 2: B) Continue
+        let continueButton = app.webViews.firstMatch.buttons["Continue"]
+        _ = continueButton.waitForExistence(timeout: timeout)
+        continueButton.tap()
+
+        // Step 3: A) Ensure password page is ready
+        // Now that we're using a two-step email page -> password page flow,
+        // the UITests need a stronger signal that the password page is ready.
+        let displayedEmailConfirmation = app.webViews.textFields[testUsername]
+        _ = displayedEmailConfirmation.waitForExistence(timeout: timeout)
+
+        // Step 3: B) Enter password
         let passwordField = app.webViews.firstMatch.secureTextFields["Password"]
         if passwordField.waitForExistence(timeout: timeout) {
             passwordField.tap()
@@ -60,10 +73,10 @@ extension Robot {
         _ = loginButton.waitForExistence(timeout: timeout)
         loginButton.tap()
 
-        // Step 3: Resolve the "insecure authorization" prompt if present
+        // Step 4: Resolve the "insecure authorization" prompt if present
         attemptAppOAuthSecurity()
 
-        // Step 4: Make sure that this OAuth Application is authorized.
+        // Step 5: Make sure that this OAuth Application is authorized.
         authorizeOAuthApplication()
 
         return self


### PR DESCRIPTION
# Description

- Guard against duplicate web view navigations when the same navigation is already in-progress
- add debug logging
- previous Auth-flow debug logging was lost when removing deprecated files
- Fix UITests/Robot/Robot+Authentication.swift for new two-stage authentication (email | password on separate pages)
- Clarify and (try to) simplify relationships among AuthView, AuthView+ViewModel, AuthenticationNavigator its parent HistoryNavigator, and AuthenticationNavigator's nested helper Interceptor, and Client
- Remove DispatchQueue.main.asyncAfter from auth flow