### PR TITLE
Add OAuth app to Dev seeds for local iOS dev

### DIFF
--- a/Default.xcconfig
+++ b/Default.xcconfig
@@ -18,3 +18,15 @@ PRODUCT_BUNDLE_IDENTIFIER = org.bikeindex.app
 // Deactivated for compatibility with GitHub Actions
 // TODO: Figure out how to re-enable in continuous delivery builds
 APP_SHORTCUTS_ENABLE_FLEXIBLE_MATCHING = NO
+
+// Default values for local-Rails development
+// To use these, check out https://github.com/bikeindex/bike_index
+// follow the 'Running Bike Index locally' steps and start the dev server
+// then sign-in with any seeded account (of https://github.com/bikeindex/bike_index/blob/main/db/seeds/seed_test_users.rb )
+//
+// alternatively, provide your own OAuth config in BikeIndex-development.xcconfig
+//
+API_HOST = http:\/\/localhost
+API_PORT = 3042
+API_CLIENT_ID = 9cBuxnqbhums1vun26ZfMv-91rInzdc6_G9HCulFxKs
+API_SECRET = Tcw_4Cr1-Yowsjs-E2Te0YZnVdYmeES3UJ0AhbeBE10


### PR DESCRIPTION
- Adding no-click OAuth seeds in the dev environment simplifies first-time set up and an easier entry to iOS dev + contributions
- These seeds are limited to Dev environment and thus safe to publicly share and hard-code in https://github.com/bikeindex/bike_index_ios/
- Pair with https://github.com/bikeindex/bike_index/pull/3876

