### PR TITLE
CI/CD: Deploy TestFlight on release-branch push

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -3,17 +3,21 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    branch: ["release/v*"]
+  push:
+    branches: ["release/v*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   requires-integration-tests:
-    if: startsWith(github.head_ref, 'release/v')
+    if: startsWith(github.ref_name, 'release/v')
     uses: bikeindex/bike_index_ios/.github/workflows/integration.yml@main
     secrets: inherit
 
   build-release:
-    if: startsWith(github.head_ref, 'release/v')
+    if: startsWith(github.ref_name, 'release/v')
     name: Build release archive and distribute
     runs-on: macos-26
     needs: requires-integration-tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,8 @@ on:
     branches: [ "main" ]
   pull_request:
   workflow_call: # allows delivery.yml to invoke test-suite
+  schedule:
+    - cron: '0 13 * * 4' # Thursday 9:00 AM EDT (13:00 UTC)
 
 jobs:
   build-tests:


### PR DESCRIPTION
- Current approach creates builds only when a PR is open but unfortunately this creates long-lived PRs that need regular history clean-ups
- On push allows early beta builds without polluting the open PRs list
- *Bonus* schedule Thursday morning (US East) test suite