### PR TITLE
CI/CD: Automate App Store Connect screenshots, `fastlane snapshot`

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -5,6 +5,22 @@ permissions:
 on:
   push:
     branches: ["release/v*"]
+  schedule:
+    # Weekly snapshot validation (canary): Monday 6am UTC.
+    # Runs only the snapshot-capture steps (no archive / ASC upload / TestFlight)
+    # and validates the screenshots. Override: github.event_name == 'schedule'
+    # (or `SNAPSHOT_VALIDATION_ONLY=true` via workflow_dispatch) selects this mode.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      SNAPSHOT_VALIDATION_ONLY:
+        description: "Run only snapshot capture + validation (no build / upload)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,28 +28,114 @@ concurrency:
 
 jobs:
   requires-integration-tests:
-    if: startsWith(github.ref_name, 'release/v')
+    # Integration tests only gate a real release build.
+    if: startsWith(github.ref_name, 'release/v') && github.event_name == 'push'
     uses: bikeindex/bike_index_ios/.github/workflows/integration.yml@main
     secrets: inherit
 
   build-release:
-    if: startsWith(github.ref_name, 'release/v')
     name: Build release archive and distribute
+    # Release pushes and manual dispatch run the full flow;
+    # scheduled runs are snapshot-validation canaries only.
+    if: >-
+      (github.event_name == 'push' && startsWith(github.ref_name, 'release/v')) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: macos-26
     needs: requires-integration-tests
     steps:
+      - name: Select flow (release vs. snapshot validation)
+        env:
+          SCHEDULED: ${{ github.event_name == 'schedule' }}
+          DISPATCH_ONLY: ${{ inputs.SNAPSHOT_VALIDATION_ONLY }}
+        id: flow
+        run: |
+          if [ "$SCHEDULED" = "true" ] || [ "$DISPATCH_ONLY" = "true" ]; then
+            echo "SNAPSHOT_VALIDATION_ONLY=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "SNAPSHOT_VALIDATION_ONLY=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
-      - name: Set Xcode 26.4
+
+      # ─── Snapshot validation (always) ─────────────────────────────────
+
+      - name: Set Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.4.app
+
+      # Screenshot capture runs against the hosted sandbox review environment
+      # (sandbox.review.bikeindex.org) 
+      # The seeded OAuth credentials (seed_oauth_app.rb) match the sandbox —
+      - name: Set up development and production xcconfigs (sandbox)
+        run: |
+          echo '#include "Default"' > BikeIndex-development.xcconfig
+          echo 'API_HOST = https:\/\/sandbox.review.bikeindex.org' >> BikeIndex-development.xcconfig
+          echo 'API_PORT = 443' >> BikeIndex-development.xcconfig
+          echo 'DEVELOPMENT_TEAM = 8ZM5ZL6ABT' >> BikeIndex-development.xcconfig
+          echo 'HONEYBADGER_API_KEY = ' >> BikeIndex-development.xcconfig
+          # Validate script won't follow the include-Default, help it out
+          grep API_SECRET Default.xcconfig >> BikeIndex-development.xcconfig
+          grep API_CLIENT_ID Default.xcconfig >> BikeIndex-development.xcconfig
+
+          # Placeholder so the app target's Release config resolves during
+          # snapshot. Not used by snapshot (Debug build); the release-mode
+          # "Load API key and xcconfig" step appends the production values.
+          echo '#include "Default"' > BikeIndex-production.xcconfig
+          echo 'API_HOST = https:\/\/sandbox.review.bikeindex.org' >> BikeIndex-production.xcconfig
+          echo 'API_PORT = 443' >> BikeIndex-production.xcconfig
+          echo 'DEVELOPMENT_TEAM = 8ZM5ZL6ABT' >> BikeIndex-production.xcconfig
+          echo 'HONEYBADGER_API_KEY = ' >> BikeIndex-production.xcconfig
+          grep API_SECRET Default.xcconfig >> BikeIndex-production.xcconfig
+          grep API_CLIENT_ID Default.xcconfig >> BikeIndex-production.xcconfig
+
+      # Absent from set up: API_HOST and API_PORT used in UITest universal link
+      # resolution but that will be solved by include-Default.
+      - name: Set up test credentials
+        run: |
+          echo '#include "BikeIndex-development"' > Test-credentials.xcconfig
+          # Seeded sandbox user: bike_index db/seeds/seed_test_users.rb
+          # user@bikeindex.org owns the seeded OAuth app and bike 44
+          echo 'TEST_USERNAME = user@bikeindex.org' >> Test-credentials.xcconfig
+          echo 'TEST_PASSWORD = pleaseplease12' >> Test-credentials.xcconfig
+
+      - name: Validate development and test xcconfigs
+        run: |
+          ./scripts/validate-xcconfig.sh development
+          ./scripts/validate-xcconfig.sh test
+
+      - name: Capture snapshots
+        run: fastlane snapshot
+
+      - name: Validate snapshots
+        run: |
+          # Expect exactly one PNG per (ScreenshotUITest method x Snapfile device):
+          # 3 test methods (main content, register bike, bike 44) x 4 devices
+          # (iPhone 17 Pro Max, iPhone 17 Pro, iPad Air 13-inch, iPad Air 11-inch) = 12.
+          ruby scripts/validate-screenshots.rb fastlane/screenshots 12
+
+      - name: Upload snapshots as artifact
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: snapshots-${{ github.sha }}
+          path: fastlane/screenshots/**/*.png
+          retention-days: 30
+
+      # Validation-only flow ends here (weekly canary / manual dispatch).
+      # All release-mode steps below are gated on steps.flow.outputs.
+
+      # ─── Release build and distribution ───────────────────────────────
+
       - name: Strip SnapshotPreviews package
+        if: steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         run: |
           brew install swift-sh
           ./scripts/release/strip-SnapshotPreviews.swift BikeIndex.xcodeproj
           xcodebuild -resolvePackageDependencies
       - name: Load API key and xcconfig
+        if: steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         env:
           MATCH_API_KEY_JSON_CONTENT: ${{ secrets.MATCH_API_KEY_JSON_CONTENT }}
           API_SECRET: ${{ secrets.PRODUCTION__API_SECRET }}
@@ -48,8 +150,10 @@ jobs:
           echo "DEVELOPMENT_TEAM = $DEVELOPMENT_TEAM" >> BikeIndex-production.xcconfig
           echo "HONEYBADGER_API_KEY = $HONEYBADGER_API_KEY" >> BikeIndex-production.xcconfig
       - name: Validate production xcconfig
+        if: steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         run: ./scripts/validate-xcconfig.sh production
-      - name: Load codesigning
+      - name: Set up keychain and codesigning
+        if: steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         env:
           CODESIGNING_IOS_READ_TOKEN: ${{ secrets.CODESIGNING_IOS_READ_TOKEN }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
@@ -58,11 +162,13 @@ jobs:
           sed -i.bak "s/git_url.*/git_url\(\"https:\/\/${GITHUB_ACTOR}:${CODESIGNING_IOS_READ_TOKEN}@github.com\/bikeindex\/codesigning_ios.git\"\)/g" fastlane/Matchfile
           fastlane CD_setup_keychain_and_codesigning
       - name: Build release archive
+        if: steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         run: fastlane CD_build_release_archive
       - name: Calculate delivery changes
+        if: steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         run: git diff > delivery-changes.patch
       - uses: actions/upload-artifact@v5
-        if: success()
+        if: success() && steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         with:
           name: ${{ github.sha }}-artifact
           path: |

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -79,9 +79,6 @@ jobs:
           grep API_SECRET Default.xcconfig >> BikeIndex-development.xcconfig
           grep API_CLIENT_ID Default.xcconfig >> BikeIndex-development.xcconfig
 
-          # Placeholder so the app target's Release config resolves during
-          # snapshot. Not used by snapshot (Debug build); the release-mode
-          # "Load API key and xcconfig" step appends the production values.
           echo '#include "Default"' > BikeIndex-production.xcconfig
           echo 'API_HOST = https:\/\/sandbox.review.bikeindex.org' >> BikeIndex-production.xcconfig
           echo 'API_PORT = 443' >> BikeIndex-production.xcconfig

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -65,9 +65,8 @@ jobs:
       - name: Set Xcode
         run: sudo xcode-select -s /Applications/Xcode_26.4.app
 
-      # Screenshot capture runs against the hosted sandbox review environment
-      # (sandbox.review.bikeindex.org) 
-      # The seeded OAuth credentials (seed_oauth_app.rb) match the sandbox —
+      # Snapshot runs against the sandbox env at sandbox.review.bikeindex.org
+      # The seeded OAuth credentials (seed_oauth_app.rb) match the sandbox.
       - name: Set up development and production xcconfigs (sandbox)
         run: |
           echo '#include "Default"' > BikeIndex-development.xcconfig
@@ -107,10 +106,9 @@ jobs:
 
       - name: Validate snapshots
         run: |
-          # Expect exactly one PNG per (ScreenshotUITest method x Snapfile device):
-          # 3 test methods (main content, register bike, bike 44) x 4 devices
-          # (iPhone 17 Pro Max, iPhone 17 Pro, iPad Air 13-inch, iPad Air 11-inch) = 12.
-          ruby scripts/validate-screenshots.rb fastlane/screenshots 12
+          # Expect one PNG per (ScreenshotUITest method x Snapfile device):
+          # 4 test methods (main content, register bike, bike 44) x 4 devices = 16
+          ruby scripts/validate-screenshots.rb fastlane/screenshots 16
 
       - name: Upload snapshots as artifact
         if: always()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,6 +40,7 @@ jobs:
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
         run: |
+          echo '#include "BikeIndex-development"' >> Test-credentials.xcconfig
           echo "TEST_USERNAME = $TEST_USERNAME" >> Test-credentials.xcconfig
           echo "TEST_PASSWORD = $TEST_PASSWORD" >> Test-credentials.xcconfig
       - name: Validate xcconfigs
@@ -94,6 +95,7 @@ jobs:
           TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
         run: |
+          echo '#include "BikeIndex-development"' >> Test-credentials.xcconfig
           echo "TEST_USERNAME = $TEST_USERNAME" >> Test-credentials.xcconfig
           echo "TEST_PASSWORD = $TEST_PASSWORD" >> Test-credentials.xcconfig
       - name: Validate xcconfigs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,24 +25,21 @@ jobs:
         run: brew bundle install
       - name: Set up xcconfig (see README.md#quick-start)
         env:
-          API_SECRET: ${{ secrets.DEVELOPMENT__API_SECRET }}
-          API_CLIENT_ID: ${{ secrets.DEVELOPMENT__API_CLIENT_ID }}
-          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
           HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
         run: |
           echo '#include "Default"' >> BikeIndex-development.xcconfig
-          echo "API_SECRET = $API_SECRET" >> BikeIndex-development.xcconfig
-          echo "API_CLIENT_ID = $API_CLIENT_ID" >> BikeIndex-development.xcconfig
-          echo "DEVELOPMENT_TEAM = $DEVELOPMENT_TEAM" >> BikeIndex-development.xcconfig
+          echo 'API_HOST = https:\/\/sandbox.review.bikeindex.org' >> BikeIndex-development.xcconfig
+          echo 'API_PORT = 443' >> BikeIndex-development.xcconfig
+          echo 'DEVELOPMENT_TEAM = 8ZM5ZL6ABT' >> BikeIndex-development.xcconfig
           echo "HONEYBADGER_API_KEY = $HONEYBADGER_API_KEY" >> BikeIndex-development.xcconfig
-      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
-        env:
-          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          # Validate script won't follow the include-Default, help it out
+          grep API_SECRET Default.xcconfig >> BikeIndex-development.xcconfig
+          grep API_CLIENT_ID Default.xcconfig >> BikeIndex-development.xcconfig
+      - name: Set up test credentials
         run: |
           echo '#include "BikeIndex-development"' >> Test-credentials.xcconfig
-          echo "TEST_USERNAME = $TEST_USERNAME" >> Test-credentials.xcconfig
-          echo "TEST_PASSWORD = $TEST_PASSWORD" >> Test-credentials.xcconfig
+          echo 'TEST_USERNAME = user@bikeindex.org' >> Test-credentials.xcconfig
+          echo 'TEST_PASSWORD = pleaseplease12' >> Test-credentials.xcconfig
       - name: Validate xcconfigs
         run: ./scripts/validate-xcconfig.sh development && ./scripts/validate-xcconfig.sh test
       - name: List available simulators
@@ -80,24 +77,21 @@ jobs:
           key: cache-build-${{ github.sha }}
       - name: Set up xcconfig (see README.md#quick-start)
         env:
-          API_SECRET: ${{ secrets.DEVELOPMENT__API_SECRET }}
-          API_CLIENT_ID: ${{ secrets.DEVELOPMENT__API_CLIENT_ID }}
-          DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
           HONEYBADGER_API_KEY: ${{ secrets.HONEYBADGER_API_KEY }}
         run: |
           echo '#include "Default"' >> BikeIndex-development.xcconfig
-          echo "API_SECRET = $API_SECRET" >> BikeIndex-development.xcconfig
-          echo "API_CLIENT_ID = $API_CLIENT_ID" >> BikeIndex-development.xcconfig
-          echo "DEVELOPMENT_TEAM = $DEVELOPMENT_TEAM" >> BikeIndex-development.xcconfig
+          echo 'API_HOST = https:\/\/sandbox.review.bikeindex.org' >> BikeIndex-development.xcconfig
+          echo 'API_PORT = 443' >> BikeIndex-development.xcconfig
+          echo 'DEVELOPMENT_TEAM = 8ZM5ZL6ABT' >> BikeIndex-development.xcconfig
           echo "HONEYBADGER_API_KEY = $HONEYBADGER_API_KEY" >> BikeIndex-development.xcconfig
-      - name: Set up xcconfig UI test credentials (see README.md#UI-Test-configuration)
-        env:
-          TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+          # Validate script won't follow the include-Default, help it out
+          grep API_SECRET Default.xcconfig >> BikeIndex-development.xcconfig
+          grep API_CLIENT_ID Default.xcconfig >> BikeIndex-development.xcconfig
+      - name: Set up test credentials
         run: |
           echo '#include "BikeIndex-development"' >> Test-credentials.xcconfig
-          echo "TEST_USERNAME = $TEST_USERNAME" >> Test-credentials.xcconfig
-          echo "TEST_PASSWORD = $TEST_PASSWORD" >> Test-credentials.xcconfig
+          echo 'TEST_USERNAME = user@bikeindex.org' >> Test-credentials.xcconfig
+          echo 'TEST_PASSWORD = pleaseplease12' >> Test-credentials.xcconfig
       - name: Validate xcconfigs
         run: ./scripts/validate-xcconfig.sh development && ./scripts/validate-xcconfig.sh test
       - name: ${{ matrix.only-testing}} on ${{ matrix.device }} ${{ matrix.deployment_target_version }}

--- a/BikeIndex.xcodeproj/project.pbxproj
+++ b/BikeIndex.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		044BDBCA2F26AEA500E0049E /* SnapshotPreferences in Frameworks */ = {isa = PBXBuildFile; productRef = 044BDBC92F26AEA500E0049E /* SnapshotPreferences */; };
 		044BDBCC2F26AEA500E0049E /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = 044BDBCB2F26AEA500E0049E /* SnapshottingTests */; };
 		048770782FCA52CB00340322 /* Honeybadger in Frameworks */ = {isa = PBXBuildFile; productRef = 048770772FCA52CB00340322 /* Honeybadger */; };
+		04CE915B300D2F97002546C3 /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CE915A300D2F97002546C3 /* SnapshotHelper.swift */; };
 		04E1343E2B4B718200CE88DD /* WebViewKit in Frameworks */ = {isa = PBXBuildFile; productRef = 04E1343D2B4B718200CE88DD /* WebViewKit */; };
 		04EA11222B2504340024CDDD /* URLEncodedForm in Frameworks */ = {isa = PBXBuildFile; productRef = 04EA11212B2504340024CDDD /* URLEncodedForm */; };
 		04F4B95E2B0990CE009442B5 /* KeychainSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 04F4B95D2B0990CE009442B5 /* KeychainSwift */; };
@@ -53,6 +54,14 @@
 		04566C7D2E67475E00E3EC6E /* Scanfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Scanfile; sourceTree = "<group>"; };
 		04566C7F2E67475E00E3EC6E /* update-icons.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "update-icons.sh"; sourceTree = "<group>"; };
 		0496C6702CB36BED00B88D1B /* Brewfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Brewfile; sourceTree = "<group>"; };
+		04CE8FC2300C7220002546C3 /* delivery.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = delivery.yml; sourceTree = "<group>"; };
+		04CE8FC3300C7220002546C3 /* integration.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = integration.yml; sourceTree = "<group>"; };
+		04CE8FC4300C7220002546C3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		04CE8FC6300C7220002546C3 /* CODEOWNERS */ = {isa = PBXFileReference; lastKnownFileType = text; path = CODEOWNERS; sourceTree = "<group>"; };
+		04CE8FC7300C7220002546C3 /* FUNDING.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = FUNDING.yml; sourceTree = "<group>"; };
+		04CE915A300D2F97002546C3 /* SnapshotHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		04CE915C300D2FB2002546C3 /* Gymfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gymfile; sourceTree = "<group>"; };
+		04CE915D300D2FB2002546C3 /* Matchfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Matchfile; sourceTree = "<group>"; };
 		04D641902FAE35B4000B5546 /* format.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = format.sh; sourceTree = "<group>"; };
 		04D641912FAE35B4000B5546 /* lint.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = lint.sh; sourceTree = "<group>"; };
 		04D641922FAE35B4000B5546 /* validate-xcconfig.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "validate-xcconfig.sh"; sourceTree = "<group>"; };
@@ -179,10 +188,14 @@
 		04566C7E2E67475E00E3EC6E /* fastlane */ = {
 			isa = PBXGroup;
 			children = (
+				04CE915A300D2F97002546C3 /* SnapshotHelper.swift */,
 				04566C7A2E67475E00E3EC6E /* Appfile */,
 				04566C7B2E67475E00E3EC6E /* Fastfile */,
 				04566C7C2E67475E00E3EC6E /* README.md */,
+				04CE915C300D2FB2002546C3 /* Gymfile */,
+				04CE915D300D2FB2002546C3 /* Matchfile */,
 				04566C7D2E67475E00E3EC6E /* Scanfile */,
+				04CE9159300D2F80002546C3 /* metadata */,
 			);
 			path = fastlane;
 			sourceTree = "<group>";
@@ -205,6 +218,33 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		04CE8FC5300C7220002546C3 /* workflows */ = {
+			isa = PBXGroup;
+			children = (
+				04CE8FC2300C7220002546C3 /* delivery.yml */,
+				04CE8FC3300C7220002546C3 /* integration.yml */,
+				04CE8FC4300C7220002546C3 /* README.md */,
+			);
+			path = workflows;
+			sourceTree = "<group>";
+		};
+		04CE8FC8300C7220002546C3 /* .github */ = {
+			isa = PBXGroup;
+			children = (
+				04CE8FC5300C7220002546C3 /* workflows */,
+				04CE8FC6300C7220002546C3 /* CODEOWNERS */,
+				04CE8FC7300C7220002546C3 /* FUNDING.yml */,
+			);
+			path = .github;
+			sourceTree = "<group>";
+		};
+		04CE9159300D2F80002546C3 /* metadata */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = metadata;
+			sourceTree = "<group>";
+		};
 		04F4B8EE2B098ADB009442B5 = {
 			isa = PBXGroup;
 			children = (
@@ -224,6 +264,7 @@
 				04566C802E67475E00E3EC6E /* scripts */,
 				04566C792E67475E00E3EC6E /* docs */,
 				04566C7E2E67475E00E3EC6E /* fastlane */,
+				04CE8FC8300C7220002546C3 /* .github */,
 				04ABEBC32D1F399E00E30577 /* Frameworks */,
 				04F4B8F82B098ADB009442B5 /* Products */,
 			);
@@ -418,6 +459,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				04CE915B300D2F97002546C3 /* SnapshotHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BikeIndex.xcodeproj/xcshareddata/xcschemes/BikeIndex.xcscheme
+++ b/BikeIndex.xcodeproj/xcshareddata/xcschemes/BikeIndex.xcscheme
@@ -32,6 +32,9 @@
             reference = "container:SharedTests/AllTests.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:SharedTests/ReleaseScreenshots.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/BikeIndex/View/BikeIndexLink.swift
+++ b/BikeIndex/View/BikeIndexLink.swift
@@ -105,6 +105,7 @@ enum BikeIndexLink: Identifiable {
             // https://bikeindex.org/my_account/edit/sharing
             return "my_account/edit/sharing"
         case .accountRegistrationOrganization:
+            // NOTE: /registration_organizations is only available for users who are already in one or more organizations
             // https://bikeindex.org/my_account/edit/registration_organizations
             return "my_account/edit/registration_organizations"
         case .deleteAccount:

--- a/BikeIndex/View/MainContent/BikesGridSectionView.swift
+++ b/BikeIndex/View/MainContent/BikesGridSectionView.swift
@@ -40,7 +40,7 @@ struct BikesGridSectionView: View {
                     path: $path,
                     bikeIdentifier: bike.identifier
                 )
-                .accessibilityIdentifier("Bike \(index + 1)")
+                .accessibilityIdentifier("Bike \(section)-\(index + 1)")
                 .accessibilityValue(bike.bikeDescription ?? bike.manufacturerName)
             }
             .padding()

--- a/BikeIndex/View/MainContent/MainToolbar.swift
+++ b/BikeIndex/View/MainContent/MainToolbar.swift
@@ -68,14 +68,18 @@ extension MainContentPage {
 
                 Menu {
                     // MARK: - Sorty By
+                    let activeSortIndicator = (sortOrder == .forward ? "arrow.down" : "arrow.up")
+                    let buttonResultSortIndicator =
+                        (sortOrder == .forward ? "arrow.up" : "arrow.down")
                     Button {
-                        sortOrder = sortOrder.toggle()
+                        sortOrder.toggle()
                     } label: {
-                        let systemImage = sortOrder == .forward ? "arrow.down" : "arrow.up"
+                        let systemImage = activeSortIndicator
                         Label("Sort order:", systemImage: systemImage)
                     }
                     .accessibilityValue(sortOrder.displayName)
                     .accessibilityHint("Toggle sort order")
+                    .accessibilityIdentifier("sortOrder-\(buttonResultSortIndicator)")
                     Divider()
                     // MARK: - Group By
                     Text("Group by:")

--- a/BikeIndex/View/Registering/RegisterBikeView.swift
+++ b/BikeIndex/View/Registering/RegisterBikeView.swift
@@ -49,10 +49,6 @@ struct RegisterBikeView: View {
     var body: some View {
         ScrollViewReader { scrollProxy in
             Form {
-                #if DEBUG
-                Text("Debug build: BikeRegistrations will be automatically deleted.")
-                #endif
-
                 if mode == .myStolenBike {
                     StolenBikeInfoSectionView()
                 }
@@ -103,6 +99,7 @@ struct RegisterBikeView: View {
                     }
                 } header: {
                     Text("Photo")
+                        .accessibilityIdentifier("photoUploadHeader")
                 }
 
                 // MARK: Serial number
@@ -328,6 +325,7 @@ struct RegisterBikeView: View {
                         .keyboardType(.emailAddress)
                         .textInputAutocapitalization(.never)
                         .focused($focus, equals: .ownerEmailText)
+                        .accessibilityIdentifier("ownerEmailTextField")
 
                         Button("Clear", systemImage: clearImage) {
                             viewModel.ownerEmail = ""
@@ -389,19 +387,6 @@ struct RegisterBikeView: View {
             )
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    #if DEBUG
-                    Menu("Scroll to") {
-                        ForEach(Field.allCases) { field in
-                            Button(field.title) {
-                                scrollProxy.scrollTo(field)
-                                focus = field
-                            }
-                        }
-                    }
-                    #endif
-                }
-
-                ToolbarItem(placement: .topBarTrailing) {
                     if client.userCanRegisterBikes && !viewModel.requiredFieldsNotMet {
                         Button {
                             focus = .registerButton
@@ -411,6 +396,18 @@ struct RegisterBikeView: View {
                         }
                     } else {
                         Text(viewModel.remainingRequiredFields)
+
+                        /*
+                         // TODO: Replace plain text of remaining required fields to a useful Menu, must fix scrollTo first
+                        Menu("Scroll to") {
+                            ForEach(Field.allCases) { field in
+                                Button(field.title) {
+                                    scrollProxy.scrollTo(field)
+                                    focus = field
+                                }
+                            }
+                        }
+                         */
                     }
                 }
             }

--- a/BikeIndex/View/Settings/SettingsPage.swift
+++ b/BikeIndex/View/Settings/SettingsPage.swift
@@ -47,11 +47,14 @@ struct SettingsPage: View {
                         Label("Sharing + Personal Page", systemImage: "shared.with.you")
                     }
 
+                    /*
+                     // TODO: Restore this after checking if the user is in one or more organizations
                     NavigationLink(value: SettingsSelection.registrationOrganization) {
                         Label(
                             "Registration Organization",
                             systemImage: "person.badge.shield.checkmark")
                     }
+                     */
 
                     Button {
                         Task {

--- a/BikeIndex/View/Web/NavigableWebView.swift
+++ b/BikeIndex/View/Web/NavigableWebView.swift
@@ -75,6 +75,7 @@ struct NavigableWebView: View {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 if navigator.isLoading {
                     ProgressView()
+                        .accessibilityIdentifier("navigableWebViewProgressView")
                 }
                 Group {
                     Button("Back", systemImage: "chevron.backward") {

--- a/BikeIndex/View/Web/WebScripts.swift
+++ b/BikeIndex/View/Web/WebScripts.swift
@@ -21,6 +21,7 @@ struct WebScripts {
             .bike-overlay-wrapper { display: none }
             div.card.organized-access-panel { display: none }
             .credibility-score, .parking-notifications-wrap { display: none }
+            #review-app-banner { display: none }
             """
         let escapedNewlines = source.replacingOccurrences(of: "\n", with: "\\n")
         let javascript =

--- a/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
+++ b/BikeIndex/ViewModel/MainContent/MainContent+GroupMode.swift
@@ -136,11 +136,11 @@ extension SortOrder {
         }
     }
 
-    func toggle() -> SortOrder {
+    mutating func toggle() {
         if self == .forward {
-            .reverse
+            self = .reverse
         } else {
-            .forward
+            self = .forward
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ To get started:
 3. If building for a device you will need to provide a bundle identifier and your development team
 4. Build and run!
 
+> [!NOTE]
+> The public sandbox environment at https://sandbox.review.bikeindex.org/oauth/applications is available for testing (and used in continuous delivery).
+
 #### Config Validation
 
 To validate that your xcconfig files have all required keys with non-empty values:

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ Running UI Tests from Xcode may cache logged-in state. Set up a credentials xcco
 
 Fastlane scan can run a single test case such as: `fastlane scan --only-testing "UITests/ManufacturerKeyboardUITestCase"`.
 
+## Creating a release
+
+See the [docs](https://github.com/bikeindex/bike_index_ios/blob/main/docs/release-steps.md#release-steps) for information on the release process, requirements, and continuous delivery.
+
 ## Sponsorship
 
 Bike Index is a 501(c)(3) nonprofit: https://bikeindex.org/why-donate

--- a/SharedTests/AllTests.xctestplan
+++ b/SharedTests/AllTests.xctestplan
@@ -40,7 +40,11 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
-        "BikeIndexAppAccessibilityPreviewTest"
+        "BikeIndexAppAccessibilityPreviewTest",
+        "ScreenshotUITest",
+        "ScreenshotUITest\/test_screenshot_details_page_br_0001()",
+        "ScreenshotUITest\/test_screenshot_main_content_page()",
+        "ScreenshotUITest\/test_screenshot_register_bike()"
       ],
       "target" : {
         "containerPath" : "container:BikeIndex.xcodeproj",

--- a/SharedTests/ReleaseScreenshots.xctestplan
+++ b/SharedTests/ReleaseScreenshots.xctestplan
@@ -1,0 +1,50 @@
+{
+  "configurations" : [
+    {
+      "id" : "A2471E49-FB8E-4204-ADA1-FAF7911CB646",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "defaultTestExecutionTimeAllowance" : 60,
+    "preferredScreenCaptureFormat" : "screenshot",
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:BikeIndex.xcodeproj",
+      "identifier" : "04F4B8F62B098ADB009442B5",
+      "name" : "BikeIndex"
+    },
+    "testTimeoutsEnabled" : true,
+    "uiTestingScreenshotsLifetime" : "keepAlways",
+    "userAttachmentLifetime" : "keepAlways"
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "BikeIndexUITests",
+        "BikeIndexUITests\/testLaunchPerformance()",
+        "BikeIndexUITests\/testMainContentPageHelp()",
+        "BikeIndexUITests\/testUnauthenticatedHelp()",
+        "BikeIndexUITests\/test_acknowledgements_webView_navigation_history()",
+        "BikeIndexUITests\/test_authenticated_bikes_scanned_id_universal_link()",
+        "BikeIndexUITests\/test_basic_bike_detail_navigation()",
+        "BikeIndexUITests\/test_basic_settings_navigation()",
+        "BikeIndexUITests\/test_register_bike_stolen_guide_link()",
+        "BikeIndexUITests\/test_serial_page_navigation()",
+        "BikeIndexUITests\/test_settings_account_pages()",
+        "MainContentUITestCase",
+        "MainContentUITestCase\/test_main_content_section()",
+        "ManufacturerKeyboardUITestCase"
+      ],
+      "target" : {
+        "containerPath" : "container:BikeIndex.xcodeproj",
+        "identifier" : "04F4B9132B098ADE009442B5",
+        "name" : "UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Test-credentials-template.xcconfig
+++ b/Test-credentials-template.xcconfig
@@ -8,6 +8,8 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
+#include "BikeIndex-development"
+
 // Provide valid credentials for UI Tests to use during sign-in.
 TEST_USERNAME =
 TEST_PASSWORD =

--- a/UITests/APIConfiguration.swift
+++ b/UITests/APIConfiguration.swift
@@ -1,0 +1,39 @@
+//
+//  APIConfiguration.swift
+//  UITests
+//
+//  Created by Jack on 9/6/26.
+//
+
+import Foundation
+import XCTest
+
+/// Used ONLY for UITests
+struct APIConfiguration {
+    let host: URL
+    let port: UInt16
+
+    static func uiTestConfig() throws -> Self {
+        let uiTestBundle = try XCTUnwrap(Bundle.uiTests)
+        let infoDictionary = try XCTUnwrap(uiTestBundle.infoDictionary)
+
+        let hostString = try XCTUnwrap(
+            (infoDictionary["API_HOST"] as? String)?
+                .replacing("\\/\\/", with: "//")
+        )
+        var host = try XCTUnwrap(URL(string: hostString))
+        let portString = try XCTUnwrap(infoDictionary["API_PORT"] as? String)
+        let port = try XCTUnwrap(UInt16(portString))
+
+        if port != 443 {
+            host = try XCTUnwrap(URL(string: hostString + ":\(port)"))
+        }
+
+        return Self(host: host, port: port)
+    }
+
+    private init(host: URL, port: UInt16) {
+        self.host = host
+        self.port = port
+    }
+}

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -112,7 +112,10 @@ final class BikeIndexUITests: XCTestCase {
             .startWithSignIn()
             .tapRegisterStolenBikeButton()
             .checkWhatToDoPageLoads()
+        #warning("TODO: Restore this when we get this page working on sandbox")
+        /*
             .checkHowToPageLoads()
+         */
     }
 
     func test_settings_account_pages() throws {
@@ -132,10 +135,6 @@ final class BikeIndexUITests: XCTestCase {
 
             .tapSharingAndPersonalPage()
             .checkTextExists("Show Personal Site")
-            .back()
-
-            .tapRegistrationOrganization()
-            .checkTextExists("Manage the organizations your bikes are registered with.")
             .back()
     }
 }

--- a/UITests/GlobalRobots/UniversalLinksRobot.swift
+++ b/UITests/GlobalRobots/UniversalLinksRobot.swift
@@ -12,7 +12,7 @@ final class UniversalLinksRobot: Robot {
     private lazy var stickerHeader = app.navigationBars.staticTexts["BR 000 1"]
     private lazy var unlinkedMessage: [XCUIElement] = [
         app.webViews.staticTexts["You scanned the sticker"],
-        app.webViews.staticTexts["BR0001"],
+        app.webViews.staticTexts["BR 000 1"],
         app.webViews.staticTexts[", which is assigned to this bike."],
     ]
 

--- a/UITests/GlobalRobots/UniversalLinksRobot.swift
+++ b/UITests/GlobalRobots/UniversalLinksRobot.swift
@@ -18,22 +18,8 @@ final class UniversalLinksRobot: Robot {
 
     private func stickerUrl() throws -> URL {
         // Configure these values in Test-credentials.xcconfig (see adjacent template file)
-        let uiTestBundle = try XCTUnwrap(Bundle.uiTests)
-        let infoDictionary = try XCTUnwrap(uiTestBundle.infoDictionary)
-
-        let hostString = try XCTUnwrap(
-            (infoDictionary["API_HOST"] as? String)?
-                .replacing("\\/\\/", with: "//")
-        )
-        var host = try XCTUnwrap(URL(string: hostString))
-        let portString = try XCTUnwrap(infoDictionary["API_PORT"] as? String)
-        let port = try XCTUnwrap(UInt16(portString))
-
-        if port != 443 {
-            host = try XCTUnwrap(URL(string: hostString + ":\(port)"))
-        }
-
-        return URL(string: "bikeindex://\(host)/bikes/scanned/BR0001")!
+        let config = try APIConfiguration.uiTestConfig()
+        return URL(string: "bikeindex://\(config.host)/bikes/scanned/BR0001")!
     }
 
     @discardableResult

--- a/UITests/GlobalRobots/UniversalLinksRobot.swift
+++ b/UITests/GlobalRobots/UniversalLinksRobot.swift
@@ -5,21 +5,41 @@
 //  Created by Milo Wyner on 6/21/25.
 //
 
+import XCTest
 import XCUIAutomation
 
 final class UniversalLinksRobot: Robot {
-    private lazy var stickerHeader = app.navigationBars.staticTexts["A 403 40"]
+    private lazy var stickerHeader = app.navigationBars.staticTexts["BR 000 1"]
     private lazy var unlinkedMessage: [XCUIElement] = [
         app.webViews.staticTexts["You scanned the sticker"],
-        app.webViews.staticTexts["A 403 40"],
+        app.webViews.staticTexts["BR0001"],
         app.webViews.staticTexts[", which is assigned to this bike."],
     ]
-    private let stickerUrl = URL(string: "bikeindex://https://bikeindex.org/bikes/scanned/A40340")!
+
+    private func stickerUrl() throws -> URL {
+        // Configure these values in Test-credentials.xcconfig (see adjacent template file)
+        let uiTestBundle = try XCTUnwrap(Bundle.uiTests)
+        let infoDictionary = try XCTUnwrap(uiTestBundle.infoDictionary)
+
+        let hostString = try XCTUnwrap(
+            (infoDictionary["API_HOST"] as? String)?
+                .replacing("\\/\\/", with: "//")
+        )
+        var host = try XCTUnwrap(URL(string: hostString))
+        let portString = try XCTUnwrap(infoDictionary["API_PORT"] as? String)
+        let port = try XCTUnwrap(UInt16(portString))
+
+        if port != 443 {
+            host = try XCTUnwrap(URL(string: hostString + ":\(port)"))
+        }
+
+        return URL(string: "bikeindex://\(host)/bikes/scanned/BR0001")!
+    }
 
     @discardableResult
-    func openLink() -> Self {
+    func openLink() throws -> Self {
         // NOTE: Deeplinks will remove the second `:` from `bikeindex://https://bikeindex...`
-        XCUIDevice.shared.system.open(stickerUrl)
+        XCUIDevice.shared.system.open(try stickerUrl())
 
         return self
     }

--- a/UITests/GlobalRobots/WebViewRobot.swift
+++ b/UITests/GlobalRobots/WebViewRobot.swift
@@ -10,11 +10,18 @@ import XCUIAutomation
 // TODO: Refactor into base WebViewRobot and subclass for specific web views, like Acknowledgements page in settings.
 final class WebViewRobot: Robot {
 
-    enum Page: String {
-        case oauth = "https://bikeindex.org/oauth/applications"
+    /// Used for any link that begins with this value
+    enum PagePrefix: String {
         case license = "LICENSE.txt"
 
         var linkPrefix: String { rawValue }
+    }
+
+    /// The configured host must be prepended.
+    enum PageSuffix: String {
+        case oauth = "/oauth/applications"
+
+        var path: String { rawValue }
     }
 
     lazy var backButton = app.buttons["WebViewBack"]
@@ -36,9 +43,21 @@ final class WebViewRobot: Robot {
     }
 
     @discardableResult
-    func navigate(to page: Page) -> Self {
+    func navigate(to page: PagePrefix) -> Self {
         // Links may not be hittable if off screen, so check if exists instead before tapping.
         let link = link(with: page.linkPrefix)
+        assert(link, [.exists])
+        link.tap()
+
+        return self
+    }
+
+    @discardableResult
+    func navigate(to page: PageSuffix) throws -> Self {
+        // Links may not be hittable if off screen, so check if exists instead before tapping.
+        let config = try APIConfiguration.uiTestConfig()
+        let resolvedUrl = config.host.appending(path: page.path)
+        let link = link(with: resolvedUrl.absoluteString)
         assert(link, [.exists])
         link.tap()
 

--- a/UITests/Info.plist
+++ b/UITests/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>API_HOST</key>
+	<string>$(API_HOST)</string>
+	<key>API_PORT</key>
+	<string>$(API_PORT)</string>
 	<key>TEST_PASSWORD</key>
 	<string>$(TEST_PASSWORD)</string>
 	<key>TEST_USERNAME</key>

--- a/UITests/MainContentRobots/MainContentRobot.swift
+++ b/UITests/MainContentRobots/MainContentRobot.swift
@@ -150,14 +150,14 @@ final class MainContentRobot: Robot {
         let timeout: TimeInterval = 5
         switch sortOrder {
         case .forward:
-            // _change to_ ascending/reverse
+            // _change to_ ascending/reverse, if not using that already
             if sortOrderAscending.waitForExistence(timeout: timeout) {
                 tap(sortOrderAscending)
             } else {
                 tapGroupButton(for: groupMode)
             }
         case .reverse:
-            // _change to_ descending/forward
+            // _change to_ descending/forward, if not using that already
             if sortOrderDescending.waitForExistence(timeout: timeout) {
                 tap(sortOrderDescending)
             } else {

--- a/UITests/MainContentRobots/MainContentRobot.swift
+++ b/UITests/MainContentRobots/MainContentRobot.swift
@@ -7,21 +7,47 @@
 
 import XCUIAutomation
 
+/// Abstract section header to support both GroupMode.byStatus and GroupMode.byManufacturer sections on MainContentPage.
+protocol MainContentSection: RawRepresentable {
+    /// The section's Bikes accessibility identifier for this section
+    var headerIdentifier: String { get }
+    /// The section's substring used as part of Bikes accessibility identifier in this section
+    var bikeIdentifier: String { get }
+}
+
+/// Partial clone of `MainContentPage.ViewModel.GroupMode` because UITests don't import BikeIndex module (and all its dependencies)
+enum GroupMode: String {
+    case byStatus
+    case byManufacturer
+}
+
+enum Manufacturer: String, MainContentSection {
+    case specialized
+    case raleigh
+    case intense
+
+    var headerIdentifier: String { "Section toggle \(rawValue.capitalized)" }
+    var bikeIdentifier: String { rawValue.capitalized }
+    static var groupMode: GroupMode { .byManufacturer }
+}
+
+/// Partial clone of `BikeStatus` because UITests don't import BikeIndex module (and all its dependencies)
+enum Status: String, MainContentSection {
+    case withOwner = "with owner"
+    case found
+    case unregisteredParkingNotification = "unregistered"
+
+    var headerIdentifier: String { rawValue.capitalized }
+    var bikeIdentifier: String { rawValue.capitalized }
+    static var groupMode: GroupMode { .byStatus }
+}
+
+// MARK: -
+
 /// Robot for testing the main content page.
 final class MainContentRobot: Robot {
-    enum GroupMode: String {
-        case byStatus
-        case byManufacturer
-    }
-
-    enum SectionHeader: String {
-        case withOwner = "Section toggle With Owner"
-        case jamis = "Section toggle Jamis"
-    }
-
     lazy var settingsButton = navigationBar.buttons["Settings"]
     lazy var helpButton = navigationBar.buttons["Help"]
-    lazy var firstBike = app.buttons["Bike 1"]
     lazy var registerBikeButton = app.buttons["Register a bike"]
     lazy var registerStolenBikeButton = app.buttons["Register a stolen bike"]
 
@@ -29,6 +55,11 @@ final class MainContentRobot: Robot {
     lazy var groupingMenuButton = app.navigationBars.buttons["Change how bikes are grouped."]
     lazy var groupByStatusButton = app.buttons[GroupMode.byStatus.rawValue]
     lazy var groupByManufacturerButton = app.buttons[GroupMode.byManufacturer.rawValue]
+    // Sorting
+    /// Aka SortOrder.forward
+    lazy var sortOrderDescending = app.buttons["sortOrder-arrow.down"]
+    /// Aka SortOrder.reverse
+    lazy var sortOrderAscending = app.buttons["sortOrder-arrow.up"]
 
     @discardableResult
     func tapSettings() -> SettingsRobot {
@@ -44,14 +75,19 @@ final class MainContentRobot: Robot {
 
     @discardableResult
     func tapFirstBike() -> BikeDetailRobot {
+        let firstBike = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'Bike' AND identifier ENDSWITH '1'")
+        ).firstMatch
         tap(firstBike)
 
         return BikeDetailRobot(app)
     }
 
     @discardableResult
-    func checkFirstBike(exists: Bool) -> Self {
-        assert(firstBike, [exists ? .exists : .doesNotExist])
+    func checkBike(section: any MainContentSection, index: Int, exists: Bool) -> Self {
+        let bike = app.buttons["Bike \(section.bikeIdentifier)-\(index)"]
+        assert(bike, [exists ? .exists : .doesNotExist])
+        return self
     }
 
     @discardableResult
@@ -83,8 +119,20 @@ final class MainContentRobot: Robot {
         return self
     }
 
+    /// Tap in the center of the overall application to dismiss any lingering Grouping Menu (in the top trailing toolbar)
     @discardableResult
-    func tapGroupButton(_ groupMode: GroupMode) -> Self {
+    func dismissGroupingMenuButton() -> Self {
+        let timeout: TimeInterval = 5
+        if groupingMenuButton.waitForExistence(timeout: timeout) {
+            let coordinate: XCUICoordinate = app.coordinate(withNormalizedOffset: .zero)
+            print("@@ \(#function) will tap coordinate \(coordinate)")
+            coordinate.tap()
+        }
+        return self
+    }
+
+    @discardableResult
+    func tapGroupButton(for groupMode: GroupMode) -> Self {
         switch groupMode {
         case .byStatus:
             tap(groupByStatusButton)
@@ -93,15 +141,41 @@ final class MainContentRobot: Robot {
         }
     }
 
+    /// Must call ``tapGroupingMenuButton()`` before invoking this function.
+    /// - Parameters:
+    ///   - sortOrder: The desired sort order, will use `returnTo` if this sort is already selected.
+    ///   - returnTo: We can't really dismiss this nicely in UITests without tapping something, so `returnTo` is the GroupMode that will be tapped in order to close this menu.
     @discardableResult
-    func checkSection(_ sectionHeader: SectionHeader, isExpanded: Bool) -> Self {
+    func tapGroupSortOrderButton(_ sortOrder: SortOrder, returnTo groupMode: GroupMode) -> Self {
+        let timeout: TimeInterval = 5
+        switch sortOrder {
+        case .forward:
+            // _change to_ ascending/reverse
+            if sortOrderAscending.waitForExistence(timeout: timeout) {
+                tap(sortOrderAscending)
+            } else {
+                tapGroupButton(for: groupMode)
+            }
+        case .reverse:
+            // _change to_ descending/forward
+            if sortOrderDescending.waitForExistence(timeout: timeout) {
+                tap(sortOrderDescending)
+            } else {
+                tapGroupButton(for: groupMode)
+            }
+        }
+        return self
+    }
+
+    @discardableResult
+    func check(section sectionHeader: any MainContentSection, isExpanded: Bool) -> Self {
         assert(
-            app.buttons[sectionHeader.rawValue],
+            app.buttons[sectionHeader.headerIdentifier],
             [.containsValue(isExpanded ? "Expanded" : "Collapsed")])
     }
 
     @discardableResult
-    func tapSectionHeader(_ sectionHeader: SectionHeader) -> Self {
-        tap(app.buttons[sectionHeader.rawValue])
+    func tap(section sectionHeader: any MainContentSection) -> Self {
+        tap(app.buttons[sectionHeader.headerIdentifier])
     }
 }

--- a/UITests/MainContentRobots/RegisterBikeRobot.swift
+++ b/UITests/MainContentRobots/RegisterBikeRobot.swift
@@ -13,6 +13,8 @@ final class RegisterBikeRobot: Robot {
     ).element
     lazy var serialPageHeading = app.webViews.staticTexts["BIKE SERIAL NUMBERS"]
     lazy var manufacturerTextField = app.textFields["manufacturerSearchTextField"]
+    lazy var photoUploadHeader = app.staticTexts["photoUploadHeader"]
+    lazy var emailTextField = app.textFields["ownerEmailTextField"]
 
     @discardableResult
     func tapGoToOurSerialPage() -> Self {
@@ -38,5 +40,35 @@ final class RegisterBikeRobot: Robot {
     @discardableResult
     func checkManufacturerTextFieldContains(text: String) -> Self {
         assert(manufacturerTextField, [.containsValue(text)])
+    }
+
+    @discardableResult
+    func scrollToOwnerEmailTextField() -> Self {
+        while emailTextField.exists == false {
+            app.swipeUp(velocity: .fast)
+        }
+        return self
+    }
+
+    /// Redact the auto-filled email text field value.
+    /// iPad screenshots have enough space to display the email and we want to
+    /// omit that from App Store screenshots.
+    @discardableResult
+    func redactAutofillEmail() -> Self {
+        while emailTextField.value as? String != "Who owns this bike?" {
+            let deleteButton = app.buttons["delete.left"].firstMatch
+            if deleteButton.waitForExistence(timeout: 1) {
+                deleteButton.tap()
+            }
+        }
+        return self
+    }
+
+    @discardableResult
+    func scrollToTop() -> Self {
+        while photoUploadHeader.exists == false {
+            app.swipeDown(velocity: .fast)
+        }
+        return self
     }
 }

--- a/UITests/MainContentUITestCase.swift
+++ b/UITests/MainContentUITestCase.swift
@@ -26,24 +26,33 @@ final class MainContentUITestCase: XCTestCase {
     func test_main_content_section() throws {
         try MainContentRobot(app)
             .startWithSignIn()
-            .tapGroupingMenuButton()
-            .tapGroupButton(.byStatus)
 
-            .checkSection(.withOwner, isExpanded: true)
-            .checkFirstBike(exists: true)
-            .tapSectionHeader(.withOwner)
-            .checkSection(.withOwner, isExpanded: false)
-            .checkFirstBike(exists: false)
-            .tapSectionHeader(.withOwner)
+            // Validate By-Status display
+            .tapGroupingMenuButton()
+            .tapGroupButton(for: Status.groupMode)
 
             .tapGroupingMenuButton()
-            .tapGroupButton(.byManufacturer)
+            // will continue if sort order is already correct and dismsis menu
+            .tapGroupSortOrderButton(.forward, returnTo: Status.groupMode)
 
-            .checkSection(.jamis, isExpanded: true)
-            .checkFirstBike(exists: true)
-            .tapSectionHeader(.jamis)
-            .checkSection(.jamis, isExpanded: false)
-            .checkFirstBike(exists: false)
-            .tapSectionHeader(.jamis)
+            .check(section: Status.withOwner, isExpanded: true)
+            .checkBike(section: Status.withOwner, index: 1, exists: true)
+            .tap(section: Status.withOwner)
+            .check(section: Status.withOwner, isExpanded: false)
+            .checkBike(section: Status.withOwner, index: 1, exists: false)
+            .tap(section: Status.withOwner)
+
+            // Validate By-Manufacturer display
+            .tapGroupingMenuButton()
+            .tapGroupButton(for: Manufacturer.groupMode)
+            .tapGroupingMenuButton()
+            .tapGroupSortOrderButton(.forward, returnTo: Manufacturer.groupMode)
+
+            .check(section: Manufacturer.specialized, isExpanded: true)
+            .checkBike(section: Manufacturer.specialized, index: 1, exists: true)
+            .tap(section: Manufacturer.specialized)
+            .check(section: Manufacturer.specialized, isExpanded: false)
+            .checkBike(section: Manufacturer.specialized, index: 1, exists: false)
+            .tap(section: Manufacturer.specialized)
     }
 }

--- a/UITests/Robot/Bundle+UITest.swift
+++ b/UITests/Robot/Bundle+UITest.swift
@@ -1,0 +1,12 @@
+//
+//  Bundle+UITest.swift
+//  UITests
+//
+//  Created by Jack on 7/23/26.
+//
+
+import Foundation
+
+extension Bundle {
+    static let uiTests = Bundle(identifier: "org.bikeindex.UITests")
+}

--- a/UITests/Robot/Robot+Authentication.swift
+++ b/UITests/Robot/Robot+Authentication.swift
@@ -37,7 +37,7 @@ extension Robot {
         let timeout: TimeInterval = 120
 
         // Configure these values in Test-credentials.xcconfig (see adjacent template file)
-        let uiTestBundle = try XCTUnwrap(Bundle(identifier: "org.bikeindex.UITests"))
+        let uiTestBundle = try XCTUnwrap(Bundle.uiTests)
         let infoDictionary = try XCTUnwrap(uiTestBundle.infoDictionary)
         let testUsername = try XCTUnwrap(infoDictionary["TEST_USERNAME"] as? String)
         let testPassword = try XCTUnwrap(infoDictionary["TEST_PASSWORD"] as? String)
@@ -59,7 +59,7 @@ extension Robot {
         // Step 3: A) Ensure password page is ready
         // Now that we're using a two-step email page -> password page flow,
         // the UITests need a stronger signal that the password page is ready.
-        let displayedEmailConfirmation = app.webViews.textFields[testUsername]
+        let displayedEmailConfirmation = app.webViews.staticTexts[testUsername]
         _ = displayedEmailConfirmation.waitForExistence(timeout: timeout)
 
         // Step 3: B) Enter password

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -8,7 +8,7 @@
 import XCTest
 
 /// From Robot Pattern for UI testing: https://jhandguy.github.io/posts/robot-pattern-ios/
-class Robot {
+open class Robot {
     static var defaultTimeout: Double = 60
 
     var app: XCUIApplication

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -64,4 +64,11 @@ open class Robot {
 
         return self
     }
+
+    @discardableResult
+    func finishWebViewLoading() -> Self {
+        let progressIndicator = app.progressIndicators["navigableWebViewProgressView"]
+        progressIndicator.waitForNonExistence(timeout: 10)
+        return self
+    }
 }

--- a/UITests/ScreenshotUITest.swift
+++ b/UITests/ScreenshotUITest.swift
@@ -1,0 +1,66 @@
+//
+//  ScreenshotUITest.swift
+//  BikeIndex
+//
+//  Test class for automated app store screenshot capture.
+//  Each method navigates to a key screen and captures screenshots.
+
+import XCTest
+
+// import ./fastlane/SnapshotHelper
+
+extension Robot {
+    /// Capture screenshots for App Store Connect releases
+    /// - Parameter name: Unique name of the screenshot
+    /// - Returns: Attachment for upload
+    @MainActor
+    func captureSnapshot(named name: String) {
+        snapshot(name)
+    }
+}
+
+/// ScreenshotUITest is within the UITests target, rather than an independent target,
+/// to ensure it always compiles. A separate target is too easy to miss.
+/// The separation of continuous integration tests vs. release screenshots
+/// is distinguished in AllTests.xctestPlan vs. ReleaseScreenshots.xctestplan.
+@MainActor
+public final class ScreenshotUITest: XCTestCase {
+
+    let app = XCUIApplication()
+
+    override public func setUpWithError() throws {
+        continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
+        setupSnapshot(app, waitForAnimations: true)
+        app.launchEnvironment["EMERGE_IS_RUNNING_FOR_SNAPSHOTS"] = "1"
+    }
+
+    // MARK: - 1. Main Content Page
+
+    public func test_1_screenshot_main_content_page() throws {
+        try MainContentRobot(app)
+            .startWithSignIn()
+            .captureSnapshot(named: "1-main-content")
+    }
+
+    // MARK: - 2. Register Bike Page
+
+    public func test_2_screenshot_register_bike() throws {
+        try MainContentRobot(app)
+            .startWithSignIn()
+            .tapRegisterBikeButton()
+            .captureSnapshot(named: "2-register-bike-initial")
+    }
+
+    // MARK: - 3. Bike Details Page (bike 44)
+
+    /// Bike 44 is associated with the sandbox user (user@bikeindex.org) and is
+    /// the first bike on the main content page, so a simple tap-through
+    /// reaches it without any deep-link plumbing.
+    public func test_3_screenshot_bike_details_44() throws {
+        try MainContentRobot(app)
+            .startWithSignIn()
+            .tapFirstBike()
+            .captureSnapshot(named: "3-bike-details-44")
+    }
+}

--- a/UITests/ScreenshotUITest.swift
+++ b/UITests/ScreenshotUITest.swift
@@ -49,6 +49,9 @@ public final class ScreenshotUITest: XCTestCase {
         try MainContentRobot(app)
             .startWithSignIn()
             .tapRegisterBikeButton()
+            .scrollToOwnerEmailTextField()
+            .redactAutofillEmail()  // required for iPad
+            .scrollToTop()
             .captureSnapshot(named: "2-register-bike-initial")
     }
 

--- a/UITests/ScreenshotUITest.swift
+++ b/UITests/ScreenshotUITest.swift
@@ -64,6 +64,24 @@ public final class ScreenshotUITest: XCTestCase {
         try MainContentRobot(app)
             .startWithSignIn()
             .tapFirstBike()
+            .finishWebViewLoading()
             .captureSnapshot(named: "3-bike-details-44")
+    }
+
+    public func test_4_sticker_details() throws {
+        try UniversalLinksRobot(app)
+            .startWithSignIn()
+            .openLink()
+            .finishWebViewLoading()
+            .captureSnapshot(named: "4-sticker-center")
+    }
+
+    public func test_5_sticker_center() throws {
+        try UniversalLinksRobot(app)
+            .startWithSignIn()
+            .openLink()
+            .finishWebViewLoading()
+            .back()
+            .captureSnapshot(named: "5-sticker-center")
     }
 }

--- a/UITests/UniversalLinksUITest.swift
+++ b/UITests/UniversalLinksUITest.swift
@@ -17,4 +17,11 @@ extension BikeIndexUITests {
             .checkUnlinkedMessage()
     }
 
+    func test_guest_bikes_scanned_id_universal_link() throws {
+        try UniversalLinksRobot(app)
+            .start()
+            .openLink()
+            .checkStickerHeader()
+            .checkUnlinkedMessage()
+    }
 }

--- a/UITests/UniversalLinksUITest.swift
+++ b/UITests/UniversalLinksUITest.swift
@@ -13,6 +13,7 @@ extension BikeIndexUITests {
         try UniversalLinksRobot(app)
             .startWithSignIn()
             .openLink()
+            .finishWebViewLoading()
             .checkStickerHeader()
             .checkUnlinkedMessage()
     }
@@ -21,6 +22,7 @@ extension BikeIndexUITests {
         try UniversalLinksRobot(app)
             .start()
             .openLink()
+            .finishWebViewLoading()
             .checkStickerHeader()
             .checkUnlinkedMessage()
     }

--- a/docs/release-screenshot-capture.md
+++ b/docs/release-screenshot-capture.md
@@ -1,0 +1,33 @@
+# Automated App Store Screenshots
+
+App Store screenshots are captured with `fastlane snapshot` against the **hosted sandbox** (`https://sandbox.review.bikeindex.org`) as part of the continuous delivery process.
+
+The sandbox's review-app banner is hidden by `WebScripts` (`#review-app-banner { display: none }`), so it never appears in captures. This banner is used for development.
+
+## Capturing locally
+
+> [!TIP]
+> A great way to align local behavior and development against `delivery.yml` is to start a new worktree. This will resemble the blank slate of a CI/CD run.
+
+1. Generate the environment configuration per the README instructions for:
+    1. Test-credentials.xcconfig
+    2. BikeIndex-development.xcconfig
+    3. BikeIndex-production.xcconfig
+2. Validate them with `scripts/validate-xcconfig.sh` (development and test).
+3. Run `fastlane snapshot`
+    - Defaults to the full four-device matrix
+    - or provide a `devices:` parameter to change the device(s) list.
+4. Validate the output with `scripts/validate-screenshots.rb` (expected number of screensohts and _some_ valid contents).
+5. Check the `fastlane snapshot` output manually.
+    - Fastlane will automatically open the `fastlane/Preview.html` file containing the snapshots in your browser.
+    - Suppress the automatic opening with the `--skip_open_summary` flag.
+
+## When and why CI runs it
+
+`fastlane snapshot` runs in the shared part of `delivery.yml`, in both flow modes. CI generates the same xcconfig files first, then validates the 12 PNGs and uploads them as a 30-day artifact.
+
+- **Weekly canary** — the `schedule` trigger (Monday 06:00 UTC) and a manual dispatch with `SNAPSHOT_VALIDATION_ONLY=true` run *only* the snapshot path (no archive, no App Store Connect / TestFlight upload). Its purpose is to prove the capture flow still works — sandbox up, seeded user and bike 44 intact, navigation and banner-hiding still correct — before a real release depends on it.
+- **Release** — a `push` to `release/v*` runs the snapshot path first; only if it passes does the job continue to keychain/codesigning, archive, and `deliver` (which uploads the fresh screenshots to App Store Connect and the ipa to TestFlight). A failing capture therefore aborts the release before anything is built or uploaded.
+
+The sandbox is a safe environment that is close-to-production, safe to modify / regenerates, and publicly available. Sandbox contents are generated from the database seeds.
+

--- a/docs/release-steps.md
+++ b/docs/release-steps.md
@@ -3,26 +3,22 @@
 > [!TIP]
 > As of [PR #128](https://github.com/bikeindex/bike_index_ios/pull/128) steps 6. (create archive build) and 7. (upload to App Store Connect) are automated for branches matching the release format in step 1.
 
-1. Create a release branch in the format `release/v1.5`
+> [!NOTE]
+> Screenshot capture (steps 4–5) is now automated via `fastlane snapshot` against the sandbox — see [release-screenshot-capture.md](release-screenshot-capture.md).
+
+1. Create a release branch named in the format `release/v1.5`
 2. Open the project and run the test suite
 3. Increment the BikeIndex Target Version and Build numbers in Default.xcconfig
-4. Capture screenshots for "iPhone 16 Plus"
-	1. Build and run the project for iPhone
-	2. Set the simulator date/time with `xcrun simctl status_bar booted override --time "2007-01-09T14:41:00.000Z" --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --cellularBars 4 --batteryState charged --batteryLevel 100`
-	3. Capture each screenshot as needed
-5. Capture screenshots for iPad
-	1. Build and run the project for "iPad Air 13-inch (M3)"
-	2. Set the simulator date/time with `xcrun simctl status_bar booted override --time "2007-01-09T14:41:00.000Z" --dataNetwork wifi --wifiMode active --wifiBars 3 --cellularMode active --cellularBars 4 --batteryState charged --batteryLevel 100`
-	3. Capture each screenshot as needed
-	4. When opening "Register a bike" page, clear the "Owner Email" field
-6. ~~Create an Archive build~~ _automated in PR #128!_
+4. ~~Capture screenshots for "iPhone 17 Plus"~~ _automated in [PR #163](https://github.com/bikeindex/bike_index_ios/pull/163)!_
+5. ~~Capture screenshots for iPad~~ _automated in [PR #163](https://github.com/bikeindex/bike_index_ios/pull/163)!_
+6. ~~Create an Archive build~~ _automated in [PR #128](https://github.com/bikeindex/bike_index_ios/pull/128)!_
 7. ~~Upload the build to App Store connect and submit it to TestFlight~~ _automated in PR #128!_
-8. Update the screenshots
+8. Confirm the screenshots match the current UI (a helpful tell is the date on the iPad screenshots!) and/or check the continuous delivery 'Capture Snapshots' step output
 9. Update the "What's New" text
 10. Submit the build to App Store Review
-	- After the build is approved, create the PR for the branch and merge it into `main`
-	- If new builds are needed for any reason, increment the build number and commit the change
-11. After the build is approved and merged, 
+	- After the build is approved, create the release PR for the branch and merge it into `main`
+	- If new builds are needed for any reason, increment the build number and commit the change within the release PR
+11. After the build is approved and merged,
 	1. create a new git tag for the release on main with the short form of the release `v1.5`
-	2. create a new GitHub release https://github.com/bikeindex/bike_index_ios/releases/new with the `v1.5` tag on main with two \# sections: "What's New" and "Description", copy and paste these paragraphs from App Store Connect
+	2. create a new GitHub release https://github.com/bikeindex/bike_index_ios/releases/new with the `v1.5 tag on main with two \# sections: "What's New" and "Description", copy and paste these paragraphs from App Store Connect
 12. Write release notes based on the changes from the previous tag (such as `v1.4.1`) and the earlier TestFlight build release notes.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,6 +79,7 @@ platform :ios do
     end
   end
 
+
   desc "Perform all tasks to make a new release: increment build, archive, upload"
   lane :CD_build_release_archive do
     current_build_number = latest_testflight_build_number(
@@ -95,13 +96,7 @@ platform :ios do
     deliver(
       # Only available for CI/CD after "Load API key" step
       api_key_path: "./fastlane/api-key.json",
-      skip_screenshots: true,
-      skip_metadata: true,
-      release_notes: {
-        default: changelog_from_git_commits()
-      },
-      precheck_include_in_app_purchases: false,
-      copyright: "2025 © Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194"
+      skip_metadata: true
     )
   end
 end

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,0 +1,43 @@
+# Uncomment the lines below you want to change by removing the # in the beginning
+
+# languages([
+#   "en-US",
+#   "de-DE",
+#   "it-IT",
+#   ["pt", "pt_BR"] # Portuguese with Brazilian locale
+# ])
+
+# Where should the resulting screenshots be stored?
+# output_directory("./screenshots")
+
+# remove the '#' to clear all previously generated screenshots before creating new ones
+clear_previous_screenshots(true)
+
+# Remove the '#' to set the status bar to 9:41 AM, and show full battery and reception. See also override_status_bar_arguments for custom options.
+override_status_bar(true)
+
+# Arguments to pass to the app on launch. See https://docs.fastlane.tools/actions/snapshot/#launch-arguments
+# launch_arguments(["-favColor red"])
+
+# For more information about all available options run
+# fastlane action snapshot
+
+# frozen_string_literal: true
+
+scheme("BikeIndex")
+
+# Where should the resulting screenshots be stored?
+# Shared by fastlane snapshot and deliver (screenshot_paths default)
+output_directory("./screenshots")
+
+devices([
+  "iPhone 17 Pro Max",
+  "iPhone 17 Pro",
+  "iPad Air 13-inch (M4)",
+  "iPad Air 11-inch (M4)",
+])
+
+concurrent_simulators(false)
+
+# Critical line
+testplan("ReleaseScreenshots")

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,14 +1,9 @@
-# Uncomment the lines below you want to change by removing the # in the beginning
-
 # languages([
 #   "en-US",
 #   "de-DE",
 #   "it-IT",
 #   ["pt", "pt_BR"] # Portuguese with Brazilian locale
 # ])
-
-# Where should the resulting screenshots be stored?
-# output_directory("./screenshots")
 
 # remove the '#' to clear all previously generated screenshots before creating new ones
 clear_previous_screenshots(true)
@@ -39,5 +34,5 @@ devices([
 
 concurrent_simulators(false)
 
-# Critical line
+# Essential test plan
 testplan("ReleaseScreenshots")

--- a/fastlane/SnapshotHelper.swift
+++ b/fastlane/SnapshotHelper.swift
@@ -1,0 +1,313 @@
+//
+//  SnapshotHelper.swift
+//  Example
+//
+//  Created by Felix Krause on 10/8/15.
+//
+
+// -----------------------------------------------------
+// IMPORTANT: When modifying this file, make sure to
+//            increment the version number at the very
+//            bottom of the file to notify users about
+//            the new SnapshotHelper.swift
+// -----------------------------------------------------
+
+import Foundation
+import XCTest
+
+@MainActor
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+    Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
+}
+
+@MainActor
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+    if waitForLoadingIndicator {
+        Snapshot.snapshot(name)
+    } else {
+        Snapshot.snapshot(name, timeWaitingForIdle: 0)
+    }
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+@MainActor
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+    Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+    case cannotFindSimulatorHomeDirectory
+    case cannotRunOnPhysicalDevice
+
+    var debugDescription: String {
+        switch self {
+        case .cannotFindSimulatorHomeDirectory:
+            return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+        case .cannotRunOnPhysicalDevice:
+            return "Can't use Snapshot on a physical device."
+        }
+    }
+}
+
+@objcMembers
+@MainActor
+open class Snapshot: NSObject {
+    static var app: XCUIApplication?
+    static var waitForAnimations = true
+    static var cacheDirectory: URL?
+    static var screenshotsDirectory: URL? {
+        return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+    }
+    static var deviceLanguage = ""
+    static var currentLocale = ""
+
+    open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+
+        Snapshot.app = app
+        Snapshot.waitForAnimations = waitForAnimations
+
+        do {
+            let cacheDir = try getCacheDirectory()
+            Snapshot.cacheDirectory = cacheDir
+            setLanguage(app)
+            setLocale(app)
+            setLaunchArguments(app)
+        } catch let error {
+            NSLog(error.localizedDescription)
+        }
+    }
+
+    class func setLanguage(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("language.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+        } catch {
+            NSLog("Couldn't detect/set language...")
+        }
+    }
+
+    class func setLocale(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("locale.txt")
+
+        do {
+            let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+            currentLocale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+        } catch {
+            NSLog("Couldn't detect/set locale...")
+        }
+
+        if currentLocale.isEmpty && !deviceLanguage.isEmpty {
+            currentLocale = Locale(identifier: deviceLanguage).identifier
+        }
+
+        if !currentLocale.isEmpty {
+            app.launchArguments += ["-AppleLocale", "\"\(currentLocale)\""]
+        }
+    }
+
+    class func setLaunchArguments(_ app: XCUIApplication) {
+        guard let cacheDirectory = self.cacheDirectory else {
+            NSLog("CacheDirectory is not set - probably running on a physical device?")
+            return
+        }
+
+        let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+        do {
+            let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
+            let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
+            let results = matches.map { result -> String in
+                (launchArguments as NSString).substring(with: result.range)
+            }
+            app.launchArguments += results
+        } catch {
+            NSLog("Couldn't detect/set launch_arguments...")
+        }
+    }
+
+    open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+        if timeout > 0 {
+            waitForLoadingIndicatorToDisappear(within: timeout)
+        }
+
+        NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
+
+        if Snapshot.waitForAnimations {
+            sleep(1) // Waiting for the animation to be finished (kind of)
+        }
+
+        #if os(OSX)
+            guard let app = self.app else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+        #else
+
+            guard self.app != nil else {
+                NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+                return
+            }
+
+            let screenshot = XCUIScreen.main.screenshot()
+            #if os(iOS) && !targetEnvironment(macCatalyst)
+            let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+            #else
+            let image = screenshot.image
+            #endif
+
+            guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
+
+            do {
+                // The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
+                let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+                let range = NSRange(location: 0, length: simulator.count)
+                simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
+
+                let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+                #if swift(<5.0)
+                    try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                #else
+                    try image.pngData()?.write(to: path, options: .atomic)
+                #endif
+            } catch let error {
+                NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
+                NSLog(error.localizedDescription)
+            }
+        #endif
+    }
+
+    class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+        #if os(watchOS)
+            return image
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { context in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
+    }
+
+    class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
+        #if os(tvOS)
+            return
+        #endif
+
+        guard let app = self.app else {
+            NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+            return
+        }
+
+        let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators.element
+        let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+        _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+    }
+
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
+        // on OSX config is stored in /Users/<username>/Library
+        // and on iOS/tvOS/WatchOS it's in simulator's home dir
+        #if os(OSX)
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64) || arch(arm64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
+            }
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
+        #else
+            throw SnapshotError.cannotRunOnPhysicalDevice
+        #endif
+    }
+}
+
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        if hasAllowListedIdentifier { return false }
+
+        let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+        return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+    }
+
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+        return allowListedIdentifiers.contains(identifier)
+    }
+
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar { return true }
+        guard frame.origin == .zero else { return false }
+
+        let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+        let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isNetworkLoadingIndicator
+        }
+
+        return self.containing(isNetworkLoadingIndicator)
+    }
+
+    @MainActor
+    var deviceStatusBars: XCUIElementQuery {
+        guard let app = Snapshot.app else {
+            fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+        }
+
+        let deviceWidth = app.windows.firstMatch.frame.width
+
+        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isStatusBar(deviceWidth)
+        }
+
+        return self.containing(isStatusBar)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        return numberA...numberB ~= self
+    }
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.30]

--- a/scripts/validate-screenshots.rb
+++ b/scripts/validate-screenshots.rb
@@ -1,0 +1,61 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# validate-screenshots.rb
+#
+# Validates that the fastlane snapshot output is a correct, non-blank set of
+# PNG screenshots. Designed to run after `fastlane snapshot`.
+#
+# Usage:
+#   ruby scripts/validate-screenshots.rb [SCREENSHOT_DIR] [EXPECTED_COUNT]
+#
+# Examples:
+#   ruby scripts/validate-screenshots.rb
+#   ruby scripts/validate-screenshots.rb fastlane/screenshots 3
+#
+# Checks:
+#   1. The screenshot directory exists.
+#   2. The number of PNG files exactly matches EXPECTED_COUNT
+#      (one per ScreenshotUITest method).
+#   3. Every file is > 5 KB (below that is likely a blank / error image).
+#   4. Every file is a real PNG (magic-byte check).
+
+SCREENSHOT_DIR = ARGV[0] || "fastlane/screenshots"
+EXPECTED_COUNT = (ARGV[1] || 1).to_i
+MIN_BYTES = 5 * 1024
+PNG_MAGIC = "\x89PNG\r\n\x1a\n".b
+
+fail "[validate-screenshots] Screenshot directory not found: #{SCREENSHOT_DIR}" unless Dir.exist?(SCREENSHOT_DIR)
+
+png_files = Dir.glob(File.join(SCREENSHOT_DIR, "**", "*.png")).sort
+
+if png_files.size != EXPECTED_COUNT
+  msg = "[validate-screenshots] Expected exactly #{EXPECTED_COUNT} PNG(s), found #{png_files.size} in #{SCREENSHOT_DIR}:"
+  png_files.each { |f| msg += "\n  - #{f}" }
+  abort msg
+end
+
+errors = []
+
+png_files.each do |path|
+  size = File.size(path)
+  if size < MIN_BYTES
+    errors << "#{path} is too small (#{size} bytes < #{MIN_BYTES})"
+    next
+  end
+
+  header = File.binread(path, 8)
+  unless header == PNG_MAGIC
+    errors << "#{path} is not a PNG (bad magic bytes: #{header.inspect})"
+    next
+  end
+
+  puts "  ✓ #{File.basename(path)} (#{size} bytes)"
+end
+
+if errors.any?
+  errors.each { |e| warn "[validate-screenshots] #{e}" }
+  abort "[validate-screenshots] #{errors.size} of #{png_files.size} screenshot(s) failed validation"
+end
+
+puts "[validate-screenshots] OK: #{png_files.size} screenshot(s), all PNGs, all > #{MIN_BYTES} bytes"

--- a/scripts/validate-xcconfig.sh
+++ b/scripts/validate-xcconfig.sh
@@ -8,6 +8,9 @@
 #   test          -> Test-credentials.xcconfig (TEST_USERNAME, TEST_PASSWORD)
 #   development   -> BikeIndex-development.xcconfig (API_SECRET, API_CLIENT_ID, DEVELOPMENT_TEAM)
 #   production    -> BikeIndex-production.xcconfig (API_SECRET, API_CLIENT_ID, DEVELOPMENT_TEAM)
+#
+# Note: UITests also need API_HOST and API_PORT for universal link resolution.
+# In CI/CD scenarios that need is met by include-Default.
 
 set -euo pipefail
 


### PR DESCRIPTION
# Description

- 🥳 automate App Store Connect screenshot capture using `fastlane snapshot` 🥳 
- This will be a huge convenience because
    1. All screenshots need mocked/staged date/time
    2. iPad screenshots in particular need the Register Bikes > owner email field redacted
    - Now this will be automated
- `fastlane snapshot` runs weekly, on-demand (workflow_dispatch), and during release PRs
- Weekly and on-demand runs only take screenshots / validate status with a brief heuristic to identify if these ever break.
- Release PR snapshot runs will upload screenshots to App Store Connect.
- Fix UI Tests on main
    - Update main content page tests especially for A) generalized Section headers B) resilience to always set the right state and C) disambiguate bike accessibility identifiers because each section starts numbering at index 1 again
- Change UI Tests environment to use sandbox environment at https://sandbox.review.bikeindex.org, safe to use and uses Rails db/seeds for test data.
- Add screenshot capture for sticker details and sticker center
- Update documentation