### PR TITLE
cicd: Update upload-artifact@v5 -> @v7

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,3 +5,7 @@ Image details: https://github.com/actions/runner-images/blob/main/images/macos/m
 ### Required CI checks
 
 Required CI checks can be found in GitHub > Settings > Rulesets > [Default ruleset] > Require status checks to pass > Show additional settings
+
+### Updating actions created by GitHub
+
+The allowed reusable workflows listed at https://github.com/bikeindex/bike_index_ios/settings/actions are version-gated. Be sure to update this list when incrementing the version of an action.

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Calculate delivery changes
         if: steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         run: git diff > delivery-changes.patch
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: success() && steps.flow.outputs.SNAPSHOT_VALIDATION_ONLY != 'true'
         with:
           name: ${{ github.sha }}-artifact

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -96,7 +96,7 @@ jobs:
         run: ./scripts/validate-xcconfig.sh development && ./scripts/validate-xcconfig.sh test
       - name: ${{ matrix.only-testing}} on ${{ matrix.device }} ${{ matrix.deployment_target_version }}
         run: fastlane scan --only-testing="${{ matrix.only-testing }}" --device="${{ matrix.device }}" --deployment-target-version="${{ matrix.deployment_target_version }}" --test_without_building=true
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: test_output_${{ matrix.device }}_${{ matrix.only-testing }}


### PR DESCRIPTION
# Description

- Old version 5 is marked deprecated
- Update note about https://github.com/bikeindex/bike_index_ios/settings/actions
