### PR TITLE
tests: Restore checkHowToPageLoads for stolen bike guide link

### DIFF
--- a/SharedTests/AllTests.xctestplan
+++ b/SharedTests/AllTests.xctestplan
@@ -38,9 +38,9 @@
       }
     },
     {
-      "parallelizable" : true,
       "skippedTests" : [
         "BikeIndexAppAccessibilityPreviewTest",
+        "BikeIndexUITests\/testLaunchPerformance()",
         "ScreenshotUITest",
         "ScreenshotUITest\/test_screenshot_details_page_br_0001()",
         "ScreenshotUITest\/test_screenshot_main_content_page()",

--- a/UITests/BikeIndexUITests.swift
+++ b/UITests/BikeIndexUITests.swift
@@ -112,10 +112,7 @@ final class BikeIndexUITests: XCTestCase {
             .startWithSignIn()
             .tapRegisterStolenBikeButton()
             .checkWhatToDoPageLoads()
-        #warning("TODO: Restore this when we get this page working on sandbox")
-        /*
             .checkHowToPageLoads()
-         */
     }
 
     func test_settings_account_pages() throws {

--- a/UITests/GlobalRobots/UniversalLinksRobot.swift
+++ b/UITests/GlobalRobots/UniversalLinksRobot.swift
@@ -9,6 +9,7 @@ import XCTest
 import XCUIAutomation
 
 final class UniversalLinksRobot: Robot {
+    let timeout: TimeInterval = 15
     private lazy var stickerHeader = app.navigationBars.staticTexts["BR 000 1"]
     private lazy var unlinkedMessage: [XCUIElement] = [
         app.webViews.staticTexts["You scanned the sticker"],
@@ -32,7 +33,7 @@ final class UniversalLinksRobot: Robot {
 
     @discardableResult
     func checkStickerHeader() -> Self {
-        assert(stickerHeader, [.exists])
+        assert(stickerHeader, [.exists], timeout: timeout)
 
         return self
     }
@@ -40,7 +41,7 @@ final class UniversalLinksRobot: Robot {
     @discardableResult
     func checkUnlinkedMessage() -> Self {
         for message in unlinkedMessage {
-            assert(message, [.exists])
+            assert(message, [.exists], timeout: timeout)
         }
 
         return self

--- a/UITests/GlobalRobots/UniversalLinksRobot.swift
+++ b/UITests/GlobalRobots/UniversalLinksRobot.swift
@@ -9,7 +9,7 @@ import XCTest
 import XCUIAutomation
 
 final class UniversalLinksRobot: Robot {
-    let timeout: TimeInterval = 15
+    let timeout: TimeInterval = 45
     private lazy var stickerHeader = app.navigationBars.staticTexts["BR 000 1"]
     private lazy var unlinkedMessage: [XCUIElement] = [
         app.webViews.staticTexts["You scanned the sticker"],

--- a/UITests/GlobalRobots/UniversalLinksRobot.swift
+++ b/UITests/GlobalRobots/UniversalLinksRobot.swift
@@ -9,7 +9,6 @@ import XCTest
 import XCUIAutomation
 
 final class UniversalLinksRobot: Robot {
-    let timeout: TimeInterval = 45
     private lazy var stickerHeader = app.navigationBars.staticTexts["BR 000 1"]
     private lazy var unlinkedMessage: [XCUIElement] = [
         app.webViews.staticTexts["You scanned the sticker"],
@@ -33,7 +32,7 @@ final class UniversalLinksRobot: Robot {
 
     @discardableResult
     func checkStickerHeader() -> Self {
-        assert(stickerHeader, [.exists], timeout: timeout)
+        assert(stickerHeader, [.exists])
 
         return self
     }
@@ -41,7 +40,7 @@ final class UniversalLinksRobot: Robot {
     @discardableResult
     func checkUnlinkedMessage() -> Self {
         for message in unlinkedMessage {
-            assert(message, [.exists], timeout: timeout)
+            assert(message, [.exists])
         }
 
         return self

--- a/UITests/GlobalRobots/UniversalLinksRobot.swift
+++ b/UITests/GlobalRobots/UniversalLinksRobot.swift
@@ -11,7 +11,7 @@ import XCUIAutomation
 final class UniversalLinksRobot: Robot {
     private lazy var stickerHeader = app.navigationBars.staticTexts["BR 000 1"]
     private lazy var unlinkedMessage: [XCUIElement] = [
-        app.webViews.staticTexts["You scanned the sticker"],
+        app.webViews.staticTexts["You scanned"],
         app.webViews.staticTexts["BR 000 1"],
         app.webViews.staticTexts[", which is assigned to this bike."],
     ]

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -9,7 +9,7 @@ import XCTest
 
 /// From Robot Pattern for UI testing: https://jhandguy.github.io/posts/robot-pattern-ios/
 open class Robot {
-    static var defaultTimeout: Double = 60
+    static var defaultTimeout: Double = 90
 
     var app: XCUIApplication
 

--- a/UITests/Robot/Robot.swift
+++ b/UITests/Robot/Robot.swift
@@ -66,10 +66,10 @@ open class Robot {
     }
 
     @discardableResult
-    func finishWebViewLoading() -> Self {
-        // SwiftUI.ProgressView == XCUIElement.ElementType.activityIndicator
+    func finishWebViewLoading(timeout: TimeInterval = Robot.defaultTimeout) -> Self {
+        // also known as SwiftUI.ProgressView
         let activityIndicator = app.activityIndicators["navigableWebViewProgressView"]
-        assert(activityIndicator, [.doesNotExist], timeout: 15)
+        assert(activityIndicator, [.doesNotExist], timeout: timeout)
         return self
     }
 


### PR DESCRIPTION
# Description

- Now that Rails server PR https://github.com/bikeindex/bike_index/pull/4231 has been merged the 'How to' guide page loads in the sandbox environment again.
- Thus we can restore this UI test.
